### PR TITLE
add operators in GF256

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ import QRCoders: makeblocks, geterrcorrblock, interleave, emptymatrix,
                encodedata, ecblockinfo, padencodedmessage, makemasks, addformat,
                placedata!
 import QRCoders.Polynomial: Poly, antilogtable, logtable, generator,
-                          mult, divide, geterrorcorrection
+                            gfpow2, gflog2, mult, divide, geterrorcorrection
 
 include("tst_operation.jl")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,11 +8,14 @@ import QRCoders: makeblocks, geterrcorrblock, interleave, emptymatrix,
                characterscapacity, modeindicators, getcharactercountindicator,
                encodedata, ecblockinfo, padencodedmessage, makemasks, addformat,
                placedata!
-import QRCoders.Polynomial: Poly, antilogtable, logtable, generator,
-                            gfpow2, gflog2, mult, divide, geterrorcorrection
+import QRCoders.Polynomial: Poly, antilogtable, logtable, generator, iszeropoly,
+                            rpadzeros, rstripzeros, gfpow2, gflog2, mult, divide,
+                            euclidean_divide, geterrorcorrection
+
+randpoly(n::Int) = Poly([rand(0:255, n-1)..., rand(1:255)])
 
 include("tst_operation.jl")
-
+    
 @testset "Test set for encoding modes" begin
     @test getmode("2983712983") == Numeric()
     @test getmode("ABCDEFG1234 \$%*+-./:") == Alphanumeric()

--- a/test/tst_operation.jl
+++ b/test/tst_operation.jl
@@ -25,8 +25,8 @@ end
     c = divide(a, b)
     @test mult(b, c) == mult(c, b) == a
 
-    ## divide and antilogtable
+    ## divide and gfpow2
     ap, bp, cp = [rand(1:255) for _ in 1:3]
-    a, b, c = getindex.(Ref(logtable), [ap, bp, cp])
-    @test mult(divide(a, b), c) == logtable[mod(ap - bp + cp, 255)]
+    a, b, c = gfpow2.([ap, bp, cp])
+    @test mult(divide(a, b), c) == gfpow2(ap - bp + cp)
 end

--- a/test/tst_operation.jl
+++ b/test/tst_operation.jl
@@ -3,23 +3,44 @@
 ## Euclidean division of polynomials
 @testset "Euclidean division" begin
     ## use Euclidean operator to obtain `geterrorcorrection`
-    geterrcode(f::Poly, n::Int) = f << n % generator(n)
+    geterrcode(f::Poly, n::Int) = rpadzeros(f << n % generator(n), n)
     ### message polynomial f(x) with degree ≤ 31
-    fdeg, n = rand(1:31), rand(1:10)
-    f = Poly([rand(1:255) for _ in 1:(fdeg+1)])
+    fdeg, n = rand(1:155), rand(1:100)
+    f = randpoly(fdeg)
     err = geterrorcorrection(f, n) ## error correction code
     rem = geterrcode(f, n) ## remainder of Euclidean division
     @test rem == err
 
+    ## systematic decoding
+    fdeg, n = rand(1:155), rand(1:100)
+    rawmsg = randpoly(fdeg)
+    msg = rawmsg << n + geterrorcorrection(f, n)
+    @test msg.coeff[(n + 1):end] == rawmsg.coeff
+
     ## operator ÷, %, *
-    f = Poly([rand(0:255, 15)..., rand(1:255)]) # f(x) with degree == 15
-    g = Poly([rand(0:255, 7)..., rand(1:255)]) # g(x) with degree == 7
+    ### leading term != 0
+    f, g = randpoly(rand(1:255)), randpoly(rand(1:255))
     q, r = f ÷ g, f % g # remainder
-    @test all(iszero, (f + g * q + r).coeff)
+    @test iszeropoly(f + g * q + r)
+    ### leading term allowed to be 0
+    f, g = Poly(rand(0:255, rand(1:255))), Poly(rand(0:255, rand(1:255)))
+    q, r = f ÷ g, f % g
+    @test iszeropoly(f + g * q + r)
+    ### g is a constant
+    f, g = randpoly(rand(1:255)), Poly([rand(1:255)])
+    q, r = f ÷ g, f % g
+    @test iszeropoly(f + g * q + r)
+    ### g(x) = x
+    f, g = randpoly(rand(1:255)), Poly([0, 1, 0, 0])
+    q, r = f ÷ g, f % g
+    @test q == Poly(f.coeff[2:end]) && r == Poly([first(f.coeff)])
+    ### divide zero
+    @test_throws DivideError randpoly(rand(1:255)) ÷ Poly([0, 0, 0])
+    @test_throws DivideError randpoly(rand(1:255)) % Poly([0, 0])
+    @test_throws DivideError euclidean_divide(randpoly(rand(1:255)), Poly([0]))
 end
 
-## Euclidean division of GF256 integers
-@testset "GF(256) division" begin
+@testset "Basic operations" begin
     ## mult and divide
     a, b = rand(0:255), rand(1:255)
     c = divide(a, b)
@@ -29,4 +50,18 @@ end
     ap, bp, cp = [rand(1:255) for _ in 1:3]
     a, b, c = gfpow2.([ap, bp, cp])
     @test mult(divide(a, b), c) == gfpow2(ap - bp + cp)
+    @test divide(0, rand(1:255)) == 0
+    @test_throws DivideError divide(rand(1:255), 0)
+    @test_throws DomainError gflog2(-1)
+    @test_throws DomainError gflog2(0)
+    
+    ## copy
+    p1 = Poly([1, 2, 3])
+    p2 = copy(p1)
+    p2.coeff[1] = 3
+    @test p2 != p1
+    
+    ## zeros
+    @test rstripzeros(Poly([1, 0, 2, 0, 0])) == Poly([1, 0, 2])
+    @test rstripzeros(Poly([0, 0, 0, 0, 0])) == Poly([0])
 end


### PR DESCRIPTION
1. add two functions `gfpow2, gflog2`
2. replace `logtable, antilogtable` by `gfpow2, gflog2` in code snippets in order to make code words more readable

Here `logtable[i]` and `antilogtalbe[n]` means 2^i and log_2(n) respectively.