### PR TITLE
minor changes

### DIFF
--- a/src/QRCoders.jl
+++ b/src/QRCoders.jl
@@ -48,17 +48,19 @@ Encoding mode for messages composed of utf-8 characters.
 struct UTF8 <: Mode end
 
 # relationships between the encoding modes
-import Base: ⊆
+import Base: issubset
 """
+    issubset(mode1::Mode, mode2::Mode)
     ⊆(mode1::Mode, mode2::Mode)
+    ⊇(mode2::Mode, mode1::Mode)
 
 Returns `true` if the character set of `mode1` is a subset of the character set of `mode2`.
 """
-⊆(::Mode, ::UTF8) = true
-⊆(mode::Mode, ::Numeric) = mode == Numeric()
-⊆(mode::Mode, ::Alphanumeric) = (mode == Alphanumeric() || mode == Numeric())
-⊆(mode::Mode, ::Byte) = (mode != UTF8() && mode != Kanji())
-⊆(mode::Mode, ::Kanji) = mode == Kanji()
+issubset(::Mode, ::UTF8) = true
+issubset(mode::Mode, ::Numeric) = mode == Numeric()
+issubset(mode::Mode, ::Alphanumeric) = (mode == Alphanumeric() || mode == Numeric())
+issubset(mode::Mode, ::Byte) = (mode != UTF8() && mode != Kanji())
+issubset(mode::Mode, ::Kanji) = mode == Kanji()
 
 # Error correction level of the QR code
 """

--- a/src/QRCoders.jl
+++ b/src/QRCoders.jl
@@ -198,7 +198,8 @@ function exportqrcode( message::AbstractString
                              mask=mask,
                              compact=compact)
 
-    if !endswith(path, ".png")
+    
+    if !contains("hello", r"\.[a-z0-9]+"i)
         path = "$path.png"
     end
 

--- a/src/QRCoders.jl
+++ b/src/QRCoders.jl
@@ -35,7 +35,8 @@ Encoding mode for messages composed of digits, characters `A`-`Z` (capital only)
 """
 struct Alphanumeric <: Mode end
 """
-Encoding mode for messages composed of one-byte characters.
+Encoding mode for messages composed of one-byte, ISO-8859-1, characters, but it also allows \
+undefined characters range from 0x80 to 0x9f.
 """
 struct Byte <: Mode end
 """

--- a/src/QRCoders.jl
+++ b/src/QRCoders.jl
@@ -200,6 +200,7 @@ function exportqrcode( message::AbstractString
 
     
     if !contains("hello", r"\.[a-z0-9]+"i)
+        @warn "No file extension detected. Attaching'.png' to the end of the file path."
         path = "$path.png"
     end
 

--- a/test/tst_overall.jl
+++ b/test/tst_overall.jl
@@ -1,7 +1,10 @@
-@testset "Exporting a QR code" begin
+@testset "Exporting a QR code to multiple file formats." begin
     message = "To be or not to be a QR code?"
-    exportqrcode(message, imgpath * "qrcode-test")
-    @test true
+    exts = ["", ".png", ".jpg"]
+    for ext in exts
+        exportqrcode(message, imgpath * "qrcode-test" * ext)
+        @test true
+    end
 end
 
 @testset "Exporting all visible ISO-8859-1 characters" begin

--- a/test/tst_overall.jl
+++ b/test/tst_overall.jl
@@ -1,10 +1,12 @@
 @testset "Exporting a QR code to multiple file formats." begin
     message = "To be or not to be a QR code?"
-    exts = ["", ".png", ".jpg"]
-    for ext in exts
-        exportqrcode(message, imgpath * "qrcode-test" * ext)
-        @test true
+    # supported types
+    for ext in ["", "jpg", "png"]
+        exportqrcode(message, imgpath * "qrcode-test.$ext")
     end
+    @test true
+    # unsupported type
+    @test_throws EncodeError exportqrcode(message, "qrcode-test.svg")
 end
 
 @testset "Exporting all visible ISO-8859-1 characters" begin


### PR DESCRIPTION
Here are the changes I have made.

- Replaced ⊆ with issubset for definitions and accessibility. 
- Allowed the export `exportqrcode` to export to more types of files by off loading file saving to FILEIO's save.
- Clarified what characters are in the `Byte` mode