### PR TITLE
Improve Polynomial operation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QRCoders"
 uuid = "f42e9828-16f3-11ed-2883-9126170b272d"
 authors = ["Jérémie Gillet <jie.gillet@gmail.com> and contributors"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This file will be saved as `./img/hello.png` (if the `img` directory already exi
 
 ### Error Correction Level
 
-QR Codes and be encoded with four error correction levels `Low`, `Medium`, `Quartile` and `High`. Error correction can restore missing data from the QR code.
+QR Codes can be encoded with four error correction levels `Low`, `Medium`, `Quartile` and `High`. Error correction can restore missing data from the QR code.
 
 * `Low` can restore up to 7% of missing codewords.
 * `Medium` can restore up to 15% of missing codewords.
@@ -93,7 +93,7 @@ QR Codes can encode data using several encoding schemes. `QRCoders.jl` supports 
 
 `Numeric` is used for messages composed of digits only, `Alphanumeric` for messages composed of digits, characters `A`-`Z` (capital only) space and `%` `*` `+` `-` `.` `/` `:` `\$`, `Kanji` for kanji for Shift JIS(Shift Japanese Industrial Standards) characters, `Bytes` for messages composed of one-byte characters(including undefined characters), and `UTF8` for messages composed of Unicode characters.
 
-Please not that QR Code reader don't always support arbitrary UTF-8 characters.
+Please note that QR Code reader don't always support arbitrary UTF-8 characters.
 
 Another thing to point out is that, for `Byte` mode, we allow the use of undefined characters(Unicode range from 0x7f to 0x9f), following the original setting in QRCode.jl. For example:
 ```jl

--- a/src/encode.jl
+++ b/src/encode.jl
@@ -12,7 +12,7 @@ using .Polynomial: Poly, geterrorcorrection
 Return the length of a UTF-8 message.
 Note: utf-8 character has flexialbe length range from 1 to 4.
 """
-utf8len(message::AbstractString) = length(Vector{UInt8}(message))
+utf8len(message::AbstractString) = length(codeunits(message))
 
 """
     bitarray2int(bits::AbstractVector)
@@ -149,7 +149,7 @@ function encodedata(message::AbstractString, ::Byte)::BitArray{1}
     vcat(int2bitarray.(UInt8.(collect(message)))...)
 end
 function encodedata(message::AbstractString, ::UTF8)::BitArray{1}
-    vcat(int2bitarray.(Vector{UInt8}(message))...)
+    vcat(int2bitarray.(codeunits(message))...)
 end
 
 function encodedata(message::AbstractString, ::Kanji)::BitArray{1}

--- a/src/tables.jl
+++ b/src/tables.jl
@@ -127,7 +127,7 @@ const charactercountlength = Dict{Mode, Array{Int, 1}}(
 
 """
 Information about the error correction codeblocks per level and version
-(ec, block1length, numofblock1s, block2length, numofblock2s).
+(eclevel, numofblock1s, block1length, numofblock2s, block2length).
 """
 const ecblockinfo = Dict{ErrCorrLevel,Array{Int,2}}(
     Low() =>

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ using QRCoders.Polynomial:
     makelogtable, antilogtable, logtable, 
     gfpow2, gflog2, gfinv, mult, divide,
     # operator for polynomials
-    iszeropoly, degree, init!, lead, zero, unit,
+    iszeropoly, degree, zero, unit,
     rpadzeros, rstripzeros, generator, 
     geterrorcorrection, euclidean_divide
                             


### PR DESCRIPTION
# Improve Polynomial operation
## Benchmark results
```jl
using BenchmarkTools
using QRCoders
using QRCode.Polynomial: Poly as OriPoly

randpoly(n::Int) = Poly([rand(0:255, n-1)..., rand(1:255)])
f1 = randpoly(100);
f2 = OriPoly(f1.coeff);
@btime f1 * f1;
@btime f2 * f2;

# 9.219 μs (2 allocations: 1.78 KiB)
# 325.375 μs (501 allocations: 555.11 KiB)
```

For the encoding part, polynomial operation is used only in `geterrorcorrection`.
```jl
exportqrcode =1> qrcode =1> encodemessage
=at most 59> getecblock =1> geterrorcorrection
```

So it decreases little of the efficiency comparing to the other operations.

Current result
| msg | cost |
| --- | --- |
| "Hello world!" | 129.871 μs (270 allocations: 19.34 KiB) |
| "0123456789" ^ 30 | 1.223 ms (1068 allocations: 96.20 KiB) |
| "HELLO WORLD" ^ 30 | 2.036 ms (1655 allocations: 157.61 KiB) |
| "HELLO WORLD" ^ 190 | 11.962 ms (8930 allocations: 882.53 KiB) |

Previous one
| input string | cost |
| --- | --- |
|  "Hello world!" | `142.909 μs (370 allocations: 32.23 KiB)`|
|  "0123456789" ^ 30 | `1.454 ms (1982 allocations: 291.95 KiB)` |
| "HELLO WORLD" ^ 30 | `2.495 ms (3200 allocations: 562.52 KiB)` |
|  "HELLO WORLD" ^ 190 | `14.310 ms (17825 allocations: 3.01 MiB)` |


However, **Efficiency of polynomial operations are important in QRDecoders.jl, since they are used frequently.**

---

Original implement:
```jl
function *(a::Poly, b::Poly)::Poly
    return sum([ c * (a << (p - 1)) for (p, c) in enumerate(b.coeff)])
end
```
Here `c * Poly`, `a << Int` and `Poly + Poly` will create new polynomials.

New one:
```jl
function *(a::Poly, b::Poly)::Poly
    prodpoly = Poly(zeros(Int, length(a) + length(b) - 1))
    @inbounds for (i, c1) in enumerate(a.coeff), (j, c2) in enumerate(b.coeff)
        prodpoly.coeff[i + j - 1] ⊻= mult(c2, c1) # column first
    end
    return prodpoly
end
```