### PR TITLE
Rewrite structure of Poly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QRCoders"
 uuid = "f42e9828-16f3-11ed-2883-9126170b272d"
 authors = ["Jérémie Gillet <jie.gillet@gmail.com> and contributors"]
-version = "1.1.1"
+version = "1.2.0"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
@@ -13,7 +13,7 @@ UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 FileIO = "1"
 ImageCore = "0.8, 0.9"
 ImageIO = "0.4, 0.5, 0.6"
-UnicodePlots = "2.12"
+UnicodePlots = "2.7 - 2.12"
 julia = "1.3"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 Create [QR Codes](https://en.wikipedia.org/wiki/QR_code) as data within Julia, or export as PNG.
 
+## Usage
 ### Create a QR Code as data
 
 Creating a QR Code couldn't be simpler.
@@ -28,35 +29,9 @@ julia> qrcode("Hello world!")
 
 The value `1(true)` represents a dark space and `0(false)` a white square.
 
-There are some optional arguments.
-
-Keyword `compact` with default value `true`. 
-
-If `compact` is `false`, the QR Code will be surrounded by a white border of width 4.
-
-```julia
-julia> qrcode("Hello world!", compact = false)
-29×29 BitMatrix:
- 0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
- 0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
- 0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
- ⋮              ⋮              ⋮              ⋮              ⋮              ⋮        
- 0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
- 0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
- 0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
-```
-
-Keywords: `eclevel`, `version`, `mode` and `mask`.
-1. The error correction level `eclevel` can be picked from four values `Low()`, `Medium()`, `Quartile()` or `High()`. Higher levels make denser QR codes.
-
-2. The version of the QR code `version` can be picked from 1 to 40. If the assigned version is too small to contain the message, the first available version is used.
-
-3. The encoding mode `mode` can be picked from five values: `Numeric()`, `Alphanumeric()`, `Byte()`, `Kanji()` or `UTF8()`. If the assigned `mode` is `nothing` or is failed to contain the message, the mode will be picked automatically.
-
-4. The mask pattern `mask` can be picked from 0 to 7. If the assigned `mask` is `nothing`, the mask pattern will picked by the penalty rules.
-
 ### Unicode Plot
-Method1, as mentioned in [issue#25](https://github.com/JuliaImages/QRCoders.jl/issues/25).
+Method 1, as mentioned in [issue#25](https://github.com/JuliaImages/QRCoders.jl/issues/25).
+
 ```jl
 julia> unicodeplotbychar("Hello world!") |> print
 █████████████████████████
@@ -74,14 +49,43 @@ julia> unicodeplotbychar("Hello world!") |> print
 ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
 ```
 
-Method2, Unicode plot by [UnicodePlots.jl](https://github.com/JuliaPlots/UnicodePlots.jl).
+Method 2, Unicode plot by [UnicodePlots.jl](https://github.com/JuliaPlots/UnicodePlots.jl).
 
 ```julia
 julia> unicodeplot("Hello world!")
 ```
-> <img src="https://cdn.jsdelivr.net/gh/zhihongecnu/PicBed3/picgo/深度截图_选择区域_20221005233521.png" width="100">
+<img src="https://cdn.jsdelivr.net/gh/juliaimages/QRCoders.jl@assets/unicodeplot.png" width="100">
 
-Note: method 2 dosen't work in text string.
+Note: method 2 dosen't work for text strings.
+
+### Optional Parameters
+
+There are some optional arguments.
+
+Keyword `width` with default value `0`. The QR Code will be surrounded by a white border of width `width`.
+
+```julia
+julia> qrcode("Hello world!", width=1)
+23×23 BitMatrix:
+ 0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+ 0  1  1  1  1  1  1  1  0  1  1  1  1  1  0  1  1  1  1  1  1  1  0
+ 0  1  0  0  0  0  0  1  0  1  0  1  0  1  0  1  0  0  0  0  0  1  0
+ ⋮              ⋮              ⋮              ⋮              ⋮     
+ 0  1  0  0  0  0  0  1  0  0  1  0  1  0  1  1  1  1  0  0  0  1  0
+ 0  1  1  1  1  1  1  1  0  1  0  1  1  0  1  1  1  0  0  1  0  0  0
+ 0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
+```
+
+Keywords `eclevel`, `version`, `mode` and `mask`:
+
+1. Error correction level `eclevel` can be picked from four values `Low()`, `Medium()`, `Quartile()` or `High()`. Higher levels make denser QR codes.
+
+2. Version of the QR code `version` can be picked from 1 to 40. If the assigned version is too small to contain the message, the first available version is used.
+
+3. Encoding mode `mode` can be picked from five values: `Numeric()`, `Alphanumeric()`, `Byte()`, `Kanji()` or `UTF8()`. If the assigned `mode` is failed to contain the message, it will be picked automatically.
+
+4. Mask pattern `mask` can be picked from 0 to 7. If the assigned `mask` is not valid, it will be picked automatically.
+
 
 ### Export a QR Code as a PNG/JPG file
 
@@ -93,18 +97,19 @@ julia> exportqrcode("Hello world!")
 
 A file will be saved at `./qrcode.png`.
 
-> ![QRCode1](https://raw.githubusercontent.com/jiegillet/QRCode.jl/966b11d0334e050992d4167bda34a495fb334a6c/qrcode.png)
+> ![QRCode1](https://cdn.jsdelivr.net/gh/juliaimages/QRCoders.jl@assets/qrcode.png)
 
-There is an extra optional parameter for `exportqrcode`:
+The keywords in `qrcode` are also available in `exportqrcode`. Moreover, there is one more keyword `targetsize` to control the size of the exported file.
 
 ```julia
-julia> exportqrcode("Hello world!", "img/hello.png", targetsize = 10, compact = true)
+julia> exportqrcode("Hello world!", "img/hello.png", targetsize = 10)
 ```
 
 This file will be saved as `./img/hello.png` (if the `img` directory already exists), have a size of (approximately) 10 centimeters and be compact. Please note that compact codes may be hard to read depending on their background.
 
-> ![QRCode2](https://raw.githubusercontent.com/jiegillet/QRCode.jl/966b11d0334e050992d4167bda34a495fb334a6c/hello.png)
+> ![QRCode2](https://cdn.jsdelivr.net/gh/juliaimages/QRCoders.jl@assets/hello.png)
 
+## About QRCode
 ### Error Correction Level
 
 QR Codes can be encoded with four error correction levels `Low`, `Medium`, `Quartile` and `High`. Error correction can restore missing data from the QR code.
@@ -130,7 +135,7 @@ julia> exportqrcode(join(Char.(0x80:0x9f)))
 ```
 ![qrcode](https://user-images.githubusercontent.com/62223937/190864667-0b24f7ad-e905-453d-a6fe-4d7d6d9feb15.png)
 
-### Acknowledgments
+## Acknowledgments
 
 `QRCoders.jl` was built following this [excellent tutorial](https://www.thonky.com/qr-code-tutorial/).
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Note: method 2 dosen't work for text strings.
 
 There are some optional arguments.
 
-Keyword `width` with default value `0`. The QR Code will be surrounded by a white border of width `width`.
+Keyword `width` with default value `0`. 
 
 ```julia
 julia> qrcode("Hello world!", width=1)
@@ -75,6 +75,8 @@ julia> qrcode("Hello world!", width=1)
  0  1  1  1  1  1  1  1  0  1  0  1  1  0  1  1  1  0  0  1  0  0  0
  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0
 ```
+
+The QR Code will be surrounded by a white border of width `width`.
 
 Keywords `eclevel`, `version`, `mode` and `mask`:
 

--- a/src/QRCoders.jl
+++ b/src/QRCoders.jl
@@ -16,7 +16,7 @@ export ErrCorrLevel, Low, Medium, Quartile, High
 export getmode, getversion
 
 # data type of Reed Solomon code
-export Poly
+export Poly, geterrcode
 
 # error type
 export EncodeError
@@ -108,17 +108,15 @@ include("encode.jl")
 include("style.jl")
 
 """
-    qrcode(message::AbstractString;
-           eclevel = Medium(),
-           version = 0,
-           mode::Union{Nothing, Mode} = nothing, 
-           mask::Union{Nothing, Int} = nothing, 
-           compact::Bool = true,
-           width::Int = 4)
+    qrcode( message::AbstractString
+          ; eclevel::ErrCorrLevel = Medium()
+          , version::Int = 0
+          , mode::Mode = Numeric()
+          , mask::Int = -1
+          , width::Int=0)
 
 Create a `BitArray{2}` with the encoded `message`, with `true` (`1`) for the black
-areas and `false` (`0`) as the white ones. If `compact` is `false`, white space
-is added around the QR code.
+areas and `false` (`0`) as the white ones.
 
 The error correction level `eclevel` can be picked from four values: `Low()`
 (7% of missing data can be restored), `Medium()` (15%), `Quartile()` (25%) or
@@ -133,17 +131,19 @@ the mode is automatically picked.
 
 The mask pattern `mask` can be picked from 0 to 7. If the assigned `mask` is `nothing`,
 the mask pattern will picked by the penalty rules.
+
+
 """
 function qrcode( message::AbstractString
                ; eclevel::ErrCorrLevel = Medium()
                , version::Int = 0
-               , mode::Union{Nothing, Mode} = nothing
-               , mask::Union{Nothing, Int} = nothing
-               , compact::Bool = true
-               , width::Int=4)
+               , mode::Mode = Numeric()
+               , mask::Int = -1
+               , compact::Bool = false
+               , width::Int = 0)
     # Determining mode and version of the QR code
     bestmode = getmode(message)
-    mode = !isnothing(mode) && bestmode ⊆ mode ? mode : bestmode
+    mode = bestmode ⊆ mode ? mode : bestmode
     
     minversion = getversion(message, mode, eclevel)
     if version < minversion # the specified version is too small
@@ -164,13 +164,13 @@ function qrcode( message::AbstractString
                   for (i, mat) in enumerate(masks)]
     
     # Pick the best mask
-    if isnothing(mask)
+    if !(0 ≤ mask ≤ 7) # invalid mask
         mask = argmin(penalty.(maskedmats)) - 1
     end
     matrix = maskedmats[mask + 1]
 
     # Format and version information
-    compact && return matrix
+    (compact || width == 0) && return matrix # keyword compact will be removed in the future
     background = falses(size(matrix) .+ (width*2, width*2))
     background[width+1:end-width, width+1:end-width] = matrix
     return background
@@ -183,7 +183,7 @@ end
                 , version::Int = 0
                 , mode::Union{Nothing, Mode} = nothing
                 , targetsize::Int = 5
-                , compact::Bool = false )
+                , width::int=4)
 
 Create a `PNG` file with the encoded `message` of approximate size `targetsize`
 cm. If `compact` is `false`, white space is added around the QR code.
@@ -206,10 +206,11 @@ function exportqrcode( message::AbstractString
                      , path::AbstractString = "qrcode.png"
                      ; eclevel::ErrCorrLevel = Medium()
                      , version::Int = 0
-                     , mode::Union{Nothing, Mode} = nothing
-                     , mask::Union{Nothing, Int} = nothing
+                     , mode::Mode = Numeric()
+                     , mask::Int = -1
                      , targetsize::Int = 5
-                     , compact::Bool = false )
+                     , compact::Bool = false
+                     , width::Int = 4 )
     # check if the image format is supported
     supportexts = ["png", "jpg"]
     if isnothing(match(r"\.\w+", path))
@@ -224,7 +225,8 @@ function exportqrcode( message::AbstractString
                              version=version,
                              mode=mode,
                              mask=mask,
-                             compact=compact)
+                             compact=compact,
+                             width=width)
     # Seems the default setting is 72 DPI
     pixels = size(matrix, 1)
     scale = ceil(Int, 72 * targetsize / 2.45 / pixels)

--- a/src/errorcorrection.jl
+++ b/src/errorcorrection.jl
@@ -32,7 +32,7 @@ end
 """
 Values of log₂1, log₂2, ..., log₂255 in GF(256).
 
-Note that it is a table of `Int64`s instead of `UInt8`s.
+It is a table of `Int` instead of `UInt8` to avoid integers overflow.
 """
 const antipowtable = let
     table = Vector{Int}(undef, 255)
@@ -41,11 +41,13 @@ const antipowtable = let
 end
 
 """
-    gfpow2(n::Int)
+    gfpow2(n::Integer)
 
 Returns 2ⁿ in GF(256).
 """
 gfpow2(n::Integer) = powtable[mod(n, 255) + 1]
+# aviod the use of `mod`
+gfpow2(n::UInt8) = powtable[n + 0x1 + (n == 0xff)]
 
 """
     gflog2(n::Integer)
@@ -53,6 +55,11 @@ gfpow2(n::Integer) = powtable[mod(n, 255) + 1]
 Returns the logarithm of n to base 2 in GF(256).
 """
 gflog2(n::Integer) = antipowtable[n]
+
+"""
+    gfinv(a::Integer)
+"""
+gfinv(a::Integer) = gfpow2(-gflog2(a))
 
 """
 Multiplication table of non-zero elements in GF(256).
@@ -84,11 +91,6 @@ function divide(a::Integer, b::Integer)
     iszero(b) && throw(DivideError())
     return divtable[a + 1, b]
 end
-
-"""
-    gfinv(a::Integer)
-"""
-gfinv(a::Integer) = gfpow2(-gflog2(a))
 
 """
     iszeropoly(p::Poly)

--- a/src/errorcorrection.jl
+++ b/src/errorcorrection.jl
@@ -1,14 +1,14 @@
 module Polynomial
 
-export Poly, geterrorcorrection
+export Poly, geterrcode
 
-import Base: length, iterate, ==, <<, +, *, ÷, %, copy, zero
+import Base: length, iterate, ==, <<, +, *, ÷, %, copy, zero, eltype
 
 """
 Data structure to encode polynomials to generate the error correction codewords.
 """
-struct Poly
-    coeff::Vector{Int}
+struct Poly{T<:Integer}
+    coeff::Vector{T}
 end
 
 """
@@ -17,7 +17,7 @@ Values of 2⁰, 2¹,..., 2²⁵⁴ in Galois Field GF(256).
 Note that 2²⁵⁵ = 1, so we don't need to store it.
 """
 const powtable = let
-    table = ones(Int, 255)
+    table = ones(UInt8, 255)
     v = 1
     for i in 2:255
         v <<= 1
@@ -31,6 +31,8 @@ end
 
 """
 Values of log₂1, log₂2, ..., log₂255 in GF(256).
+
+Note that it is a table of `Int64`s instead of `UInt8`s.
 """
 const antipowtable = let
     table = Vector{Int}(undef, 255)
@@ -43,7 +45,7 @@ end
 
 Returns 2ⁿ in GF(256).
 """
-gfpow2(n::Int) = powtable[mod(n, 255) + 1]
+gfpow2(n::Integer) = powtable[mod(n, 255) + 1]
 
 """
     gflog2(n::Integer)
@@ -55,13 +57,13 @@ gflog2(n::Integer) = antipowtable[n]
 """
 Multiplication table of non-zero elements in GF(256).
 """
-const multtable = [i*j == 0 ? 0 : gfpow2(gflog2(i) + gflog2(j)) for i in 0:255, j in 0:255]
+const multtable = [iszero(i * j) ? 0x0 : gfpow2(gflog2(i) + gflog2(j)) for i in 0:255, j in 0:255]
 
 
 """
 Division table of non-zero elements in GF(256).
 """
-const divtable = [i == 0 ? 0 : gfpow2(gflog2(i) - gflog2(j)) for i in 0:255, j in 1:255]
+const divtable = [iszero(i) ? 0x0 : gfpow2(gflog2(i) - gflog2(j)) for i in 0:255, j in 1:255]
 
 """
     mult(a::Integer, b::Integer)
@@ -79,7 +81,7 @@ end
 Division of intergers in GF(256).
 """
 function divide(a::Integer, b::Integer)
-    b == 0 && throw(DivideError())
+    iszero(b) && throw(DivideError())
     return divtable[a + 1, b]
 end
 
@@ -101,8 +103,8 @@ iszeropoly(p::Poly) = all(iszero, p)
 Remove trailing zeros from polynomial p.
 """
 rstripzeros(p::Poly) = rstripzeros!(copy(p))
-function rstripzeros!(p::Poly)
-    iszeropoly(p) && return zero(Poly)
+function rstripzeros!(p::Poly{T}) where T
+    iszeropoly(p) && return zero(Poly{T})
     deleteat!(p.coeff, findlast(!iszero, p.coeff) + 1:length(p))
     return p
 end
@@ -113,9 +115,9 @@ end
 Add zeros to the right side of p(x) such that length(p) == n.
 """
 rpadzeros(p::Poly, n::Int) = rpadzeros!(copy(p), n)
-function rpadzeros!(p::Poly, n::Int)
+function rpadzeros!(p::Poly{T}, n::Int) where T
     length(p) > n && throw("rpadzeros: length(p) > n")
-    append!(p.coeff, zeros(Int, n - length(p)))
+    append!(p.coeff, zeros(T, n - length(p)))
     return p
 end
 
@@ -134,21 +136,21 @@ end
 
 Returns the zero polynomial.
 """
-zero(::Type{Poly})= Poly(zeros(Int, 1))
+zero(::Type{Poly{T}}) where T = Poly{T}(zeros(T, 1))
 
 """
     unit(::Type)
 
 Returns the unit polynomial.
 """
-unit(::Type{Poly}) = Poly(ones(Int, 1))
+unit(::Type{Poly{T}}) where T = Poly{T}(ones(T, 1))
 
 """
     copy(p::Poly)
 
 Create a copy of polynomial p.
 """
-copy(p::Poly) = Poly(copy(p.coeff))
+copy(p::Poly{T}) where T = Poly{T}(copy(p.coeff))
 
 """
     length(p::Poly)
@@ -157,8 +159,10 @@ Return the degree of the polynomial.
 """
 length(p::Poly) = length(p.coeff)
 
+## used for iteration
 iterate(p::Poly) = iterate(p.coeff)
 iterate(p::Poly, i) = iterate(p.coeff, i)
+eltype(::Poly{T}) where T = T
 
 ==(a::Poly, b::Poly)::Bool = iszeropoly(a + b)
 
@@ -167,16 +171,22 @@ iterate(p::Poly, i) = iterate(p.coeff, i)
 
 Increase the degree of `p` by `n`.
 """
-<<(p::Poly, n::Int)::Poly = Poly(vcat(zeros(Int, n), p.coeff))
+<<(p::Poly{T}, n::Int) where T = Poly{T}(vcat(zeros(T, n), p.coeff))
 
-function +(a::Poly, b::Poly)::Poly
+function +(a::Poly{T}, b::Poly{T}) where T
     l = max(length(a), length(b))
-    return Poly([xor(get(a.coeff, i, 0), get(b.coeff, i, 0)) for i in 1:l])
+    return Poly{T}([xor(get(a.coeff, i, zero(T)), get(b.coeff, i, zero(T))) for i in 1:l])
 end
 
-*(a::Integer, p::Poly)::Poly = Poly(map(x->mult(a, x), p.coeff))
-function *(a::Poly, b::Poly)::Poly
-    prodpoly = Poly(zeros(Int, length(a) + length(b) - 1))
+"""
+    *(p, q)
+
+Multiply two polynomials or a polynomial with a scalar.
+"""
+*(a::T, p::Poly{T}) where T = Poly{T}(mult.(a, p.coeff))
+*(p::Poly{T}, a::T) where T = Poly{T}(mult.(a, p.coeff))
+function *(a::Poly{T}, b::Poly{T}) where T
+    prodpoly = Poly(zeros(T, length(a) + length(b) - 1))
     for (i, c1) in enumerate(a.coeff), (j, c2) in enumerate(b.coeff)
         @inbounds prodpoly.coeff[i + j - 1] ⊻= mult(c2, c1) # column first
     end
@@ -195,7 +205,7 @@ euclidean_divide(f::Poly, g::Poly) = euclidean_divide!(copy(f), copy(g))
 
 Implement of Euclidean division with minimized allocations.
 """
-function euclidean_divide!(f::Poly, g::Poly)
+function euclidean_divide!(f::Poly{T}, g::Poly{T}) where T
     ## remove trailing zeros
     g, f = rstripzeros!(g), rstripzeros!(f)
     iszeropoly(g) && throw(DivideError())
@@ -203,14 +213,14 @@ function euclidean_divide!(f::Poly, g::Poly)
     ## leading term of g(x)
     gn = last(gcoef)
     ## g(x) is a constant
-    if lg == 1
+    if isone(lg)
         fcoef .= divide.(fcoef, gn)
-        return f, zero(Poly)
+        return f, zero(Poly{T})
     end
     ## degree of the quotient polynomial
     quodeg = lf - lg
     ## deg(f) < deg(g)
-    quodeg < 0 && return zero(Poly), f
+    quodeg < 0 && return zero(Poly{T}), f
     ## remainder and quotient polynomial
     @inbounds for i in 0:quodeg
         leadterm = divide(fcoef[end-i], gn)
@@ -219,7 +229,7 @@ function euclidean_divide!(f::Poly, g::Poly)
         end
         fcoef[end-i] = leadterm
     end
-    quo = Poly(fcoef[end-quodeg:end]) # here @view will be a little bit slower
+    quo = Poly{T}(fcoef[end-quodeg:end]) # here @view will be a little bit slower
     deleteat!(fcoef, lf-quodeg:lf)
     return quo, f
 end
@@ -243,12 +253,14 @@ Remainder of Euclidean division.
 
 Create the Generator Polynomial of degree `n`.
 """
-generator(n::Int) = prod([Poly([gfpow2(i - 1), 1]) for i in 1:n])
+generator(n::Int) = generator(UInt8, n)
+generator(::Type{T}, n::Int) where T = prod([Poly{T}([powtable[i], one(T)]) for i in 1:n])
+
 
 """
-    geterrorcorrection(f::Poly, n::Int)
+    geterrcode(f::Poly, n::Int)
 
 Return a polynomial containing the `n` error correction codewords of `f`.
 """
-geterrorcorrection(f::Poly, n::Int) = rpadzeros!(f << n % generator(n), n)
+geterrcode(f::Poly{T}, n::Int) where T = rpadzeros!(f << n % generator(T, n), n)
 end # module

--- a/src/style.jl
+++ b/src/style.jl
@@ -27,7 +27,7 @@ end
 Uses UnicodePlots.jl to draw the QR code of `message`.
 """
 function unicodeplot(message::AbstractString; border=:none)
-    unicodeplot(qrcode(message;eclevel=Low(), compact=false, width=2); border=border) 
+    unicodeplot(qrcode(message;eclevel=Low(), width=2); border=border) 
 end
 
 ## idea by @notinaboat
@@ -58,5 +58,5 @@ Note that `true` represents black and `false` represents white in qrcode,
 which is the opposite of the image convention.
 """
 function unicodeplotbychar(message::AbstractString)
-    unicodeplotbychar(.! qrcode(message; eclevel=Low(), compact=false, width=2))
+    unicodeplotbychar(.! qrcode(message; eclevel=Low(), width=2))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,10 +29,13 @@ using QRCoders.Polynomial:
     # operator for polynomials
     iszeropoly, degree, zero, unit,
     rpadzeros, rstripzeros, generator, 
-    geterrorcorrection, euclidean_divide
-                            
-randpoly(n::Int) = Poly([rand(0:255, n-1)..., rand(1:255)])
-randpoly(range::AbstractVector{Int}) = randpoly(rand(range))
+    geterrcode, euclidean_divide
+
+# random polynomial
+randpoly(::Type{T}, n::Int) where T = Poly{T}([rand(0:255, n-1)..., rand(1:255)])
+randpoly(n::Int) = randpoly(UInt8, n)
+randpoly(::Type{T}, range::AbstractVector{Int}) where T = randpoly(T, rand(range))
+randpoly(range::AbstractVector{Int}) = randpoly(UInt8, range)
 imgpath = "testimages/"
 eclevels = [Low(), Medium(), Quartile(), High()]
 modes = [Numeric(), Alphanumeric(), Byte(), Kanji()]

--- a/test/tst_encode.jl
+++ b/test/tst_encode.jl
@@ -170,7 +170,7 @@ end
     mask = argmin(scores) - 1
     matrix = maskedmats[mask + 1]
 
-    mat = qrcode(msg; compact=true)
+    mat = qrcode(msg)
     @test penalty(matrix) == minimum(scores)
     @test mat == matrix
 end

--- a/test/tst_operation.jl
+++ b/test/tst_operation.jl
@@ -2,11 +2,11 @@
 
 ## Euclidean division of polynomials
 @testset "Euclidean division" begin
-    ## original method of `geterrorcorrection`
+    ## original method of `geterrcode`
     tail!(p::Poly)::Poly = Poly(deleteat!(p.coeff, 1))
     init!(p::Poly)::Poly = Poly(deleteat!(p.coeff, length(p)))
     Base.:(*)(a::Integer, p::Poly)::Poly = Poly(map(x->mult(a, x), p.coeff))
-    function geterrcode(a::Poly, n::Int)::Poly
+    function geterrorcorrection(a::Poly, n::Int)::Poly
         la = length(a)
         a = a << n
         g = generator(n) << la
@@ -20,14 +20,14 @@
     ### message polynomial f(x)
     fdeg, n = rand(1:155), rand(1:100)
     f = randpoly(fdeg)
-    err = geterrorcorrection(f, n) ## error correction code
-    rem = geterrcode(f, n) ## remainder of Euclidean division
+    err = geterrcode(f, n) ## error correction code
+    rem = geterrorcorrection(f, n) ## remainder of Euclidean division
     @test rem == err
 
     ## systematic decoding
     fdeg, n = rand(1:155), rand(1:100)
     rawmsg = randpoly(fdeg)
-    msg = rawmsg << n + geterrorcorrection(f, n)
+    msg = rawmsg << n + geterrcode(f, n)
     @test msg.coeff[(n + 1):end] == rawmsg.coeff
 
     ## operator ÷, %, *
@@ -40,17 +40,17 @@
     q, r = f ÷ g, f % g
     @test iszeropoly(f + g * q + r)
     ### g is a constant
-    f, g = randpoly(1:255), Poly([rand(1:255)])
+    f, g = randpoly(1:255), Poly([rand(0x1:0xff)])
     q, r = f ÷ g, f % g
     @test iszeropoly(f + g * q + r)
     ### g(x) = x
-    f, g = randpoly(2:255), Poly([0, 1, 0, 0])
+    f, g = randpoly(2:255), Poly(UInt8[0, 1, 0, 0])
     q, r = f ÷ g, f % g
     @test q == Poly(f.coeff[2:end]) && r == Poly([first(f.coeff)])
     ### divide zero
-    @test_throws DivideError randpoly(1:255) ÷ Poly([0, 0, 0])
-    @test_throws DivideError randpoly(1:255) % Poly([0, 0])
-    @test_throws DivideError euclidean_divide(randpoly(1:255), Poly([0]))
+    @test_throws DivideError randpoly(Int, 1:255) ÷ Poly([0, 0, 0])
+    @test_throws DivideError randpoly(Int, 1:255) % Poly([0, 0])
+    @test_throws DivideError euclidean_divide(randpoly(1:255), Poly(UInt8[0]))
 end
 
 @testset "Basic operations" begin
@@ -80,15 +80,16 @@ end
     @test p2 != p1
     
     ## zeros, unit, rstripzeros, rpadzeros
-    @test zero(Poly) == Poly([0])
+    @test zero(Poly{Int}) == Poly([0])
+    @test zero(Poly{UInt8}) == Poly{UInt8}([0]) == Poly([0x0])
     @test rstripzeros(Poly([1, 0, 2, 0, 0])) == Poly([1, 0, 2])
     @test rstripzeros(Poly([0, 0, 0, 0, 0])) == Poly([0])
     @test rpadzeros(Poly([1, 0, 2]), 5) == Poly([1, 0, 2, 0, 0])
     @test rpadzeros(Poly([1, 0, 2]), 3) == Poly([1, 0, 2])
     @test_throws String rpadzeros(Poly([1, 0, 2]), 2)
-    f = randpoly(1:255)
-    @test f * unit(Poly) == f == unit(Poly) * f
-    @test unit(Poly) == Poly([1])
+    f = randpoly(Int, 1:255)
+    @test f * unit(Poly{Int}) == f == unit(Poly{Int}) * f
+    @test unit(Poly{Int}) == Poly([1])
 
     ## degree
     @test degree(Poly([1, 0, 2, 0, 0])) == 2
@@ -124,7 +125,7 @@ end
 
     p = Poly(rand(UInt8, 10))
     q = Poly(rand(UInt8, 20))
-    @test Poly([1]) * p == p
+    @test Poly(UInt8[1]) * p == p
     @test p * q == q * p
     @test p + q == q + p
 
@@ -135,8 +136,10 @@ end
     a, p = rand(UInt8), randpoly(1:255)
     @test Poly([a]) * p == a * p == Int(a) * p
 
-    @test generator(2) == Poly([2, 3, 1])
-    @test generator(3) == Poly([8, 14, 7, 1])
+    @test generator(Int, 2) == Poly([2, 3, 1])
+    @test generator(Int, 3) == Poly([8, 14, 7, 1])
+    @test generator(2) == Poly{UInt8}([2, 3, 1])
+    @test generator(3) == Poly(UInt8[8, 14, 7, 1])
 
     g7 = [21, 102, 238, 149, 146, 229, 87, 0]
     @test generator(7) == Poly(map(n -> powtable[n+1], g7))
@@ -152,10 +155,10 @@ end
 
     msg = [17, 236, 17, 236, 17, 236, 64, 67, 77, 220, 114, 209, 120, 11, 91, 32]
     r = [23, 93, 226, 231, 215, 235, 119, 39, 35, 196]
-    @test geterrorcorrection(Poly(msg), 10) == Poly(r)
+    @test geterrcode(Poly(msg), 10) == Poly(r)
 
     msg = [70,247,118,86,194,6,151,50,16,236,17,236,17,236,17,236]
     r = [235, 159, 5, 173, 24, 147, 59, 33, 106, 40, 255, 172, 82, 2,
          131, 32, 178, 236]
-    @test geterrorcorrection(Poly(reverse(msg)), 18) == Poly(reverse(r))
+    @test geterrcode(Poly(reverse(msg)), 18) == Poly(reverse(r))
 end

--- a/test/tst_overall.jl
+++ b/test/tst_overall.jl
@@ -109,7 +109,7 @@ end
                 else
                     str = randstring(l)
                 end
-                matrix = qrcode(str, eclevel=eclevel, compact=false)
+                matrix = qrcode(str, eclevel=eclevel, width=4)
                 nm = size(matrix, 2)
                 image[i*s+1:i*s+nm, j*s+1:j*s+nm] = matrix
             end


### PR DESCRIPTION
Replace `Poly` by `Poly{T}`.

| version | msg/generator | cost |
| --- | --- | --- |
| current | `"Hello world!"` | **140.145 μs** (268 allocations: 17.50 KiB) |
| 1.1.1 | `"Hello world!"` | 122.512 μs (269 allocations: 19.31 KiB) |
| 0.2.0 | `"Hello world!"` | 3.930 ms (175888 allocations: 8.43 MiB) |
| current | `"Hello world!" ^ 190` | **17.367 ms** (15281 allocations: 1.07 MiB) |
| 1.1.1 | `"Hello world!" ^ 190` | 17.331 ms (15332 allocations: 1.39 MiB) |
| 0.2.0 | `"Hello world!" ^ 190` | 484.636 ms (19128212 allocations: 922.52 MiB) |