### PR TITLE
edit rule of unicodeplotbychar

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ julia> qrcode("Hello world!")
  1  1  1  1  1  1  1  0  1  0  1  1  0  1  1  1  0  0  1  0  0
 ```
 
-The value `1(true)` represents a dark space and `0(false)` a white square.
+The value `1(true)` represents a dark space and `0(false)` a white space.
 
 ### Export a QR Code as a file
 

--- a/src/QRCoders.jl
+++ b/src/QRCoders.jl
@@ -9,20 +9,22 @@ using UnicodePlots
 
 export
     # create QR code
-    qrcode, exportqrcode, exportbitmat, QRCode,
+    qrcode, exportqrcode, QRCode,
+    exportbitmat, addborder,
     # supported modes
     Mode, Numeric, Alphanumeric, Byte, Kanji, UTF8,
     # error correction levels
     ErrCorrLevel, Low, Medium, Quartile, High,
     # get information about QR code
-    getmode, getversion, qrwidth, getsegments,
+    getmode, getversion, qrwidth, 
+    getindexes, getsegments,
     # data type of Reed Solomon code
     Poly, geterrcode,
     # error type
     EncodeError,
     # QR code style
     unicodeplot, unicodeplotbychar,
-    imageinqrcode, animatebyqrcode
+    imagebyerrcor, animatebyerrcor
 
 """
 Invalid step in encoding process.
@@ -172,7 +174,7 @@ qrwidth(code::QRCode) = 4 * code.version + 17 + 2 * code.border
 
 Show the QR code in REPL using `unicodeplotbychar`.
 """
-Base.show(io::IO, code::QRCode) = print(io, unicodeplotbychar(.! qrcode(code)))
+Base.show(io::IO, code::QRCode) = print(io, unicodeplotbychar(qrcode(code)))
 
 include("tables.jl")
 include("errorcorrection.jl")
@@ -223,6 +225,8 @@ function qrcode( message::AbstractString
                , mask::Int = -1
                , compact::Bool = false
                , width::Int = 0)
+    isempty(message) && @warn(
+        "Most QR code scanners don't support empty message!")
     # Determining mode and version of the QR code
     bestmode = getmode(message)
     mode = bestmode ⊆ mode ? mode : bestmode

--- a/src/style.jl
+++ b/src/style.jl
@@ -9,8 +9,8 @@ supported list:
         2.2 split indexes into several segments(de-interleave)
     3. plot image inside QR code
         I. use error correction
-        II. use remainder bits
-        III. use remainder bits and error correction
+        II. use pad bits
+        III. use pad bits and error correction
 =#
 
 # 1. Unicode plot
@@ -42,16 +42,18 @@ function unicodeplot(message::AbstractString; border=:none)
 end
 
 ## idea by @notinaboat
-const pixelchars = [' ', '▄', '▀', '█']
+const pixelchars = ['█', '▀', '▄', ' ']
 pixelchar(block::AbstractVector) = pixelchars[2 * block[1] + block[2] + 1]
-pixelchar(bit::Bool) = pixelchars[1 + 2 * bit]
+pixelchar(bit::Bool) = bit ? pixelchars[4] : pixelchars[2]
 
 """
     unicodeplotbychar(mat::AbstractMatrix)
 
 Plot of the QR code using Unicode characters.
 
-Note that `true` represents white and `false` represents black.
+The value `1(true)` represents a dark space and `0(false)` 
+a white square. It is the same convention as QR code and 
+is the opposite of general image settings.
 """
 function unicodeplotbychar(mat::AbstractMatrix)
     m = size(mat, 1)
@@ -64,12 +66,9 @@ end
     unicodeplotbychar(message::AbstractString)
 
 Plot of the QR code using Unicode characters.
-
-Note that `true` represents black and `false` represents white in qrcode, 
-which is the opposite of the image convention.
 """
 function unicodeplotbychar(message::AbstractString)
-    unicodeplotbychar(.! qrcode(message; eclevel=Low(), width=2))
+    unicodeplotbychar(qrcode(message; eclevel=Low(), width=2))
 end
 
 # 2. locate message bits
@@ -127,12 +126,12 @@ The procedure is similar to `deinterleave` in `QRDecoders.jl`.
 function getsegments(v::Int, eclevel::ErrCorrLevel)
     # initialize
     ## get information about error correction
-    ncodewords, nb1, nc1, nb2, nc2 = ecblockinfo[eclevel][v, :]
+    necwords, nb1, nc1, nb2, nc2 = ecblockinfo[eclevel][v, :]
     ## initialize blocks
     expand(x) = (8 * x - 7):8 * x
     segments = vcat([Vector{Int}(undef, 8 * nc1) for _ in 1:nb1],
                     [Vector{Int}(undef, 8 * nc2) for _ in 1:nb2])
-    ecsegments = [Vector{Int}(undef, 8 * ncodewords) for _ in 1:nb1 + nb2]
+    ecsegments = [Vector{Int}(undef, 8 * necwords) for _ in 1:nb1 + nb2]
     # get segments from the QR code
     ## indexes of message bits
     inds = getindexes(v)
@@ -144,16 +143,16 @@ function getsegments(v::Int, eclevel::ErrCorrLevel)
     ## get blocks
     ind = length(inds) >> 3 # number of bytes
     ### error correction bytes
-    for i in ncodewords:-1:1, j in (nb1 + nb2):-1:1
+    @inbounds for i in necwords:-1:1, j in (nb1 + nb2):-1:1
         ecsegments[j][expand(i)] = @view(inds[expand(ind)])
         ind -= 1
     end
     ### message bytes
-    for i in nc2:-1:(1 + nc1), j in (nb1 + nb2):-1:(nb1 + 1)
+    @inbounds for i in nc2:-1:(1 + nc1), j in (nb1 + nb2):-1:(nb1 + 1)
         segments[j][expand(i)] = @view(inds[expand(ind)])
         ind -= 1
     end
-    for i in nc1:-1:1, j in (nb1 + nb2):-1:1
+    @inbounds for i in nc1:-1:1, j in (nb1 + nb2):-1:1
         segments[j][expand(i)] = @view(inds[expand(ind)])
         ind -= 1
     end
@@ -165,44 +164,45 @@ end
 ### I. use error correction
 
 """
-    pickindexes(errinds::AbstractVector{<:Integer}, blockinds{<:Integer}, destroy::Int)
+    pickindexes(errinds::AbstractVector{<:Integer}, blockinds{<:Integer}, modify::Int)
 
 Pick indexes from `blockinds` by `errinds`. The number of codewords that will be 
-destroyed is `destroy`. Here 1 codeword = 8 bits.
+modified is `modify`. Here 1 codeword = 8 bits.
 """
 function pickcodewords( errinds::AbstractVector{<:Integer}
-                      , blockinds::AbstractVector{<:Integer}
-                      , destroy::Int)
+                      , validbytes::AbstractVector{<:AbstractVector}
+                      , modify::Int)
     ## locate codewords
-    length(blockinds) & 7 == 0 || throw(ArgumentError(
-        "The number of indexes is not correct."))
-    blocklen = length(blockinds) >> 3
-    damges = Vector{Int}(undef, blocklen)
+    blocklen = length(validbytes)
+    modify ≥ blocklen && return validbytes
     errinds = Set(errinds) # for fast searching
-    for i in 1:blocklen
-        damges[i] = @views count(in(errinds), blockinds[8 * i - 7:8 * i])
-    end
+    damages = [count(in(errinds), bytes) for bytes in validbytes]
     ## sort by damage cost
-    inds = @views sort(1:blocklen, by=i->damges[i], rev=true)[1:destroy]
-    ## recover the codewords
-    @views vcat([blockinds[8 * i - 7:8 * i] for i in inds]...)
+    inds = @views sort(1:blocklen, by=i->damages[i], rev=true)[1:modify]
+    # inds = @views inds[1:count(!iszero, damages)] # discard the correct bits
+    @views validbytes[inds]
+end
+
+function pack2bytes(inds::AbstractVector{<:Integer})
+    n = length(inds)
+    return [inds[i:i+7] for i in 1:8:n & 7 ⊻ n] # discard remainder bits
 end
 
 """
-    imageinqrcode(code::QRCode, targetmat::AbstractMatrix, rate::Real=2/3)
+    imagebyerrcor(code::QRCode, targetmat::AbstractMatrix, rate::Real=2/3)
 
-Plot the image `targetmat` inside the QR code.
+Plot the image `targetmat` inside the QR code using error correction.
 
 In order to get the best simulation, the error correction level
 is recommended to be `High()`.
 
 The parameter `rate` is the rate of the error correction codewords
-that will be destroyed. The default value is `2/3`, which means that
-`1/2 * 2/3 = 1/3` of the error correction codewords will be destroyed.
+that will be modified. The default value is `2/3`, which means that
+`1/2 * 2/3 = 1/3` of the error correction codewords will be modified.
 """
-imageinqrcode(code::QRCode, targtemat::AbstractMatrix; rate::Real=2/3) = imageinqrcode!(copy(code), targtemat; rate=rate)
+imagebyerrcor(code::QRCode, targtemat::AbstractMatrix; rate::Real=2/3) = imagebyerrcor!(copy(code), targtemat; rate=rate)
 
-function imageinqrcode!( code::QRCode
+function imagebyerrcor!( code::QRCode
                        , targetmat::AbstractMatrix
                        ; rate::Real=2/3)
     ## check parameters
@@ -211,41 +211,44 @@ function imageinqrcode!( code::QRCode
             " It could risk to destroy the message if rate is bigger that 1."))
     border, code.border = code.border, 0 # reset border -- compat to indexes rule
     (imgx, imgy), qrlen = size(targetmat), qrwidth(code)
-    version, eclevel = code.version, code.eclevel
     qrlen ≥ max(imgx, imgy) || throw(ArgumentError("The image is too large."))
     
     ## image position
     x1, y1 = (qrlen - imgx + 1) >> 1, (qrlen - imgy + 1) >> 1
     x2, y2 = x1 + imgx - 1, y1 + imgy - 1
-    leftop = (x1 - 1, y1 - 1)
+    function isvalid(p::Int)
+        x, y = p % qrlen, p ÷ qrlen
+        x1 ≤ x ≤ x2 && y1 ≤ y ≤ y2
+    end  
 
     ## locations of message bits
+    version, eclevel = code.version, code.eclevel
     msginds, ecinds = getsegments(version, eclevel)
-    msgecinds = [vcat(inds1, inds2) for (inds1, inds2) in zip(msginds, ecinds)]
     # number of error correction codewords
-    ncodewords = length(first(ecinds)) >> 3
-    destroy = floor(Int, ncodewords * rate / 2)
-    # indexes inside the image
-    targetval(ind::Int) = targetmat[ind % qrlen - leftop[1], ind ÷ qrlen - leftop[2]]
-    function isvalid(p::Int)
-         x, y = p % qrlen, p ÷ qrlen
-         x1 ≤ x ≤ x2 && y1 ≤ y ≤ y2
-    end
-    validinds = vcat(filter!.(isvalid, msginds)...,
-                     filter!.(isvalid, ecinds)...)
+    necwords = length(first(ecinds)) >> 3
+    modify = floor(Int, necwords * rate / 2)
+
+    # valid indexes
     validmsgecinds = [vcat(inds1, inds2) for (inds1, inds2) in zip(msginds, ecinds)]
+    validbytes = [filter!.(isvalid, pack2bytes(inds)) for inds in validmsgecinds]
+    filter!.(isvalid, validmsgecinds) # filter out invalid indexes
+    validinds = vcat(validmsgecinds...)
+    # indexes inside the image
+    targetval(ind::Int) = targetmat[ind % qrlen - x1 + 1, ind ÷ qrlen - y1 + 1]
+      
     ## cost function
     penalty(newmat) = sum(newmat[validinds] .== targetval.(validinds))
-
     ## enumerate over masks
     bestmat, bestpenalty = nothing, Inf
     for mask in 0:7
         code.mask = mask
         newmat = qrcode(code)
-        for (vinds, blockinds) in zip(validmsgecinds, msgecinds) # enumerate over each blcok
+        for (vinds, vbytes) in zip(validmsgecinds, validbytes) # enumerate over each blcok
             errinds = filter(x -> newmat[x] != targetval(x), vinds)
-            inds = filter!(isvalid, pickcodewords(errinds, blockinds, destroy))
-            newmat[inds] = targetval.(inds)
+            bytes = pickcodewords(errinds, vbytes, modify)
+            @inbounds for inds in bytes
+                newmat[inds] = targetval.(inds)
+            end
         end
         newpenalty = penalty(newmat)
         if newpenalty < bestpenalty
@@ -257,7 +260,7 @@ function imageinqrcode!( code::QRCode
 end
 
 """
-    imageinqrcode( message::AbstractString
+    imagebyerrcor( message::AbstractString
                 , targetmat::AbstractMatrix
                 ; version::Int=16
                 , mode::Mode=Numeric()
@@ -265,9 +268,9 @@ end
                 , width::Int=2
                 , rate::Real=2/3)
 
-Plot the image inside the QR code of `message`.
+Plot the image inside the QR code of `message` using error correction.
 """
-function imageinqrcode( message::AbstractString
+function imagebyerrcor( message::AbstractString
                       , targetmat::AbstractMatrix
                       ; version::Int=16
                       , mode::Mode=Numeric()
@@ -275,21 +278,21 @@ function imageinqrcode( message::AbstractString
                       , width::Int=0
                       , rate::Real=2/3)
     code = QRCode(message, version=version, eclevel=eclevel, mode=mode, width=width)
-    return imageinqrcode!(code, targetmat, rate=rate)
+    return imagebyerrcor!(code, targetmat, rate=rate)
 end
 
 """
-    animatebyqrcode( codes::AbstractVector{QRCode}
-                    , targetmats::AbstractVector{<:AbstractMatrix}
-                    ; rate::Real=2/3
-                    , pixels::Int=160
-                    , fps::Int=10
-                    , filename::AbstractString="animate.gif")
+    animatebyerrcor( codes::AbstractVector{QRCode}
+                   , targetmats::AbstractVector{<:AbstractMatrix}
+                   ; rate::Real=2/3
+                   , pixels::Int=160
+                   , fps::Int=10
+                   , filename::AbstractString="animate.gif")
 
-Plot the image inside the QR code of `message` and save the animation
-to `filename`.
+Plot the image inside the QR code of `message` using error correction,
+and save the animation to `filename`.
 """
-function animatebyqrcode( codes::AbstractVector{QRCode}
+function animatebyerrcor( codes::AbstractVector{QRCode}
                         , targetmats::Vector{<:AbstractArray}
                         , filename::AbstractString="animate.gif"
                         ; rate::Real=2/3
@@ -304,10 +307,8 @@ function animatebyqrcode( codes::AbstractVector{QRCode}
     pixels = ceil(Int, pixels / width) * width
     animate = Array{Bool}(undef, pixels, pixels, length(codes))
     for (i, code) in enumerate(codes)
-        mat = imageinqrcode(code, targetmats[i], rate=rate)
+        mat = imagebyerrcor(code, targetmats[i], rate=rate)
         animate[:, :, i] = _resize(mat, pixels)
     end
     save(filename, .! animate, fps=fps)
 end
-
-### II. plot using remainder bits

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ using QRCoders:
     bitarray2int, int2bitarray, bits2bytes,
     # style
     unicodeplot, getindexes, getsegments,
-    imageinqrcode, animatebyqrcode,
+    imagebyerrcor, animatebyerrcor,
     pickcodewords
                  
 using QRCoders.Polynomial:

--- a/test/tst_construct.jl
+++ b/test/tst_construct.jl
@@ -217,7 +217,7 @@ end
     encodeddata = encodedata(msg, mode)
 
     # Getting parameters for the error correction
-    ncodewords, nb1, nc1, nb2, nc2 = ecblockinfo[eclevel][version, :]
+    necwords, nb1, nc1, nb2, nc2 = ecblockinfo[eclevel][version, :]
     requiredbits = 8 * (nb1 * nc1 + nb2 * nc2)
 
     # Pad encoded message before error correction
@@ -227,11 +227,11 @@ end
 
     # Getting error correction codes
     blocks = makeblocks(encoded, nb1, nc1, nb2, nc2)
-    ecblocks = getecblock.(blocks, ncodewords)
+    ecblocks = getecblock.(blocks, necwords)
 
     # Interleave code blocks
-    msgbits = interleave(blocks, ecblocks, ncodewords, nb1, nc1, nb2, nc2, version)
-    @test length(msgbits) == requiredbits + ncodewords * (nb1 + nb2) * 8 + remainderbits[version]
+    msgbits = interleave(blocks, ecblocks, necwords, nb1, nc1, nb2, nc2, version)
+    @test length(msgbits) == requiredbits + necwords * (nb1 + nb2) * 8 + remainderbits[version]
 
     # Pick the best mask
     matrix = emptymatrix(version)

--- a/test/tst_overall.jl
+++ b/test/tst_overall.jl
@@ -23,13 +23,13 @@ end
     modeindicator = modeindicators[mode]
     ccindicator = getcharactercountindicator(length(message), version, mode)
     encodeddata = encodedata(message, mode)
-    ncodewords, nb1, dc1, nb2, dc2 = ecblockinfo[eclevel][version, :]
+    necwords, nb1, dc1, nb2, dc2 = ecblockinfo[eclevel][version, :]
     requiredbits = 8 * (nb1 * dc1 + nb2 * dc2)
     encoded = vcat(modeindicator, ccindicator, encodeddata)
     encoded = padencodedmessage(encoded, requiredbits)
     blocks = makeblocks(encoded, nb1, dc1, nb2, dc2)
-    ecblocks = map(b->getecblock(b, ncodewords), blocks)
-    data0 = interleave(blocks, ecblocks, ncodewords, nb1, dc1, nb2, dc2, version)
+    ecblocks = map(b->getecblock(b, necwords), blocks)
+    data0 = interleave(blocks, ecblocks, necwords, nb1, dc1, nb2, dc2, version)
     matrix0 = emptymatrix(version)
     masks = makemasks(matrix0)
     image = falses((39,39*8))

--- a/test/tst_style.jl
+++ b/test/tst_style.jl
@@ -40,7 +40,7 @@ end
 
     # get segments of the QR code
     for v in 1:40
-        ncodewords, nb1, nc1, nb2, nc2 = ecblockinfo[eclevel][v, :]
+        necwords, nb1, nc1, nb2, nc2 = ecblockinfo[eclevel][v, :]
         requiredbits = 8 * (nb1 * nc1 + nb2 * nc2)
         segments, ecsegments = getsegments(v, eclevel)
         msginds = vcat(segments...)
@@ -80,20 +80,19 @@ end
 @testset "simulate image" begin
     # image in qrcode
     img = testimage("cam")
-    img = .! (Bool ∘ round).(imresize(img, 37, 37))
+    img = .!(Bool.(round.(imresize(img, 37, 37))))
     code = QRCode("HELLO WORLD", eclevel=High(), version=16, width=4)
-    mat = imageinqrcode(code, img, rate=2/3)
+    mat = imagebyerrcor(code, img, rate=2/3)
     exportbitmat(mat, "testimages/cam.png")
     @test true
-    mat = imageinqrcode("hello world!", img, version=10, width=2, rate=1.1)
-    .! mat |> unicodeplotbychar |> println
+    mat = imagebyerrcor("hello world!", img, version=10, width=2, rate=1.1)
+    mat |> unicodeplotbychar |> println
     @test true
-
 
     # test for animate
     code = QRCode("HELLO WORLD", eclevel=High(), version=16, width=4)
     code2 = QRCode("Hello julia!", eclevel=High(), version=16, width=4)
     codes = [code, code2]
-    animatebyqrcode(codes, [img, img], "testimages/cam.gif", rate=2/3)
+    animatebyerrcor(codes, [img, img], "testimages/cam.gif", rate=2/3)
     @test true
 end


### PR DESCRIPTION
This PR is separated from #39 , since it is irrelevant of linear equations.

Changes:
 1. In `unicodeplotbychar(mat)`, use the rule of QRCode instead.
 2. Minor change of the function `imagebyerrcor`
 3. Rename word `ncodewords` to `necwords`

_Images are just matrices._
In image convention, the value `1(true)` represents a **white** space and `0(false)` a **black** space. However, it is the opposite of QR codes.


Benchamark for `newmat[inds] = targetval.(inds)`
1. cost: `12.476 ms (134839 allocations: 12.62 MiB)`
2. use `.=` instead: `12.501 ms (144559 allocations: 13.80 MiB)`