### PR TITLE
Plot images

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
+StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QRCoders"
 uuid = "f42e9828-16f3-11ed-2883-9126170b272d"
 authors = ["Jérémie Gillet <jie.gillet@gmail.com> and contributors"]
-version = "1.3.1"
+version = "1.4.0"
 
 [deps]
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
@@ -16,6 +16,7 @@ FileIO = "1"
 ImageCore = "0.8, 0.9"
 ImageIO = "0.4, 0.5, 0.6"
 ImageMagick = "1"
+StatsBase = "0.33"
 UnicodePlots = "2.7 - 2.12"
 julia = "1.3"
 
@@ -23,9 +24,8 @@ julia = "1.3"
 ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
 QRDecoders = "d4999880-6331-4276-8b7d-7ee1f305cff8"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["ImageTransformations", "QRDecoders", "Test", "Random", "StatsBase", "TestImages"]
+test = ["ImageTransformations", "QRDecoders", "Test", "Random", "TestImages"]

--- a/src/QRCoders.jl
+++ b/src/QRCoders.jl
@@ -6,6 +6,7 @@ module QRCoders
 using ImageCore
 using FileIO
 using UnicodePlots
+using StatsBase
 
 export
     # create QR code

--- a/src/QRCoders.jl
+++ b/src/QRCoders.jl
@@ -24,7 +24,7 @@ export
     EncodeError,
     # QR code style
     unicodeplot, unicodeplotbychar,
-    imageinqrcode, getfreeinfo
+    imageinqrcode, getfreeinfo, getimagescore
 
 # Data types in QRCoders
 include("types.jl")

--- a/src/QRCoders.jl
+++ b/src/QRCoders.jl
@@ -18,14 +18,13 @@ export
     # get information about QR code
     getmode, getversion, qrwidth, 
     getindexes, getsegments,
-    # data type of Reed Solomon code
-    Poly, geterrcode,
+    # polynomial operations
+    Poly, geterrcode, generator_matrix,
     # error type
     EncodeError,
     # QR code style
     unicodeplot, unicodeplotbychar,
-    imagebyerrcor, animatebyerrcor,
-    generator_matrix
+    imageinqrcode, getfreeinfo
 
 # Data types in QRCoders
 include("types.jl")
@@ -48,8 +47,5 @@ include("styles/style.jl")
 
 # Generate and export QR code
 include("export.jl")
-
-# Tools for equation solving
-include("styles/equation.jl")
 
 end # module

--- a/src/encode.jl
+++ b/src/encode.jl
@@ -304,3 +304,4 @@ function addborder(matrix::AbstractMatrix, width::Int)
     background[width+1:end-width, width+1:end-width] = matrix
     return background
 end
+addborder(width::Int) = matrix -> addborder(matrix, width) # currying

--- a/src/export.jl
+++ b/src/export.jl
@@ -105,6 +105,7 @@ function exportbitmat( matrix::BitMatrix
     end
     save(path, .! _resize(matrix, pixels))
 end
+exportbitmat(path::AbstractString) = matrix -> exportbitmat(matrix, path)
 
 """
     exportqrcode( message::AbstractString

--- a/src/styles/locate.jl
+++ b/src/styles/locate.jl
@@ -49,6 +49,7 @@ getindexes(code::QRCode) = getindexes(code.version)
 Get the error correction information.
 """
 getecinfo(v::Int, eclevel::ErrCorrLevel) = @views ecblockinfo[eclevel][v, :]
+getecinfo(code::QRCode) = getecinfo(code.version, code.eclevel)
 
 """
     getsegments(code::QRCode)

--- a/src/styles/locate.jl
+++ b/src/styles/locate.jl
@@ -1,16 +1,17 @@
-# 2. Locate message bits
-## 2.1 extract indexes of message bits
+# Locate message bits
+
+## extract indexes of message bits
 
 """
     getindexes(v::Int)
 
 Extract indexes of message bits from the QR code of version `v`.
 
-The procedure is similar to `placedata!` in `matrix.jl`.
+Note: The procedure is similar to `placedata!` in `matrix.jl`.
 """
 function getindexes(v::Int)
     mat, n = emptymatrix(v), 17 + 4 * v
-    inds = Vector{Int}(undef, msgbitslen[v])
+    inds = Vector{CartesianIndex{2}}(undef, msgbitslen[v])
     col, row, ind = n, n + 1, 1
     while col > 0
         # Skip the column with the timing pattern
@@ -23,11 +24,11 @@ function getindexes(v::Int)
         # recode index if the matrix element is nothing
         for _ in 1:n
             if isnothing(mat[row, col])
-                inds[ind] = (col - 1) * n + row
+                inds[ind] = CartesianIndex(row, col)
                 ind += 1
             end
             if isnothing(mat[row, col - 1])
-                inds[ind] = (col - 2) * n + row
+                inds[ind] = CartesianIndex(row, col - 1)
                 ind += 1
             end
             row += δrow
@@ -39,8 +40,9 @@ function getindexes(v::Int)
         "The number of indexes is not correct."))
     return inds
 end
+getindexes(code::QRCode) = getindexes(code.version)
 
-## 2.2 split indexes into several segments(de-interleave)
+## split indexes into several segments(de-interleave)
 """
     getecinfo(v::Int, eclevel::ErrCorrLevel)
 
@@ -49,22 +51,21 @@ Get the error correction information.
 getecinfo(v::Int, eclevel::ErrCorrLevel) = @views ecblockinfo[eclevel][v, :]
 
 """
-    getsegments(v::Int, mode::Mode, eclevel::ErrCorrLevel)
+    getsegments(code::QRCode)
 
-Get indexes segments of the corresponding settings.
-Each of the segments has atmost 8 * 255 elements.
+Get indexes segments of the QR code.
 
-The procedure is similar to `deinterleave` in `QRDecoders.jl`.
+Note: The procedure is similar to `deinterleave` in `QRDecoders.jl`.
 """
+getsegments(code::QRCode) = getsegments(code.version, code.eclevel)
 function getsegments(v::Int, eclevel::ErrCorrLevel)
     # initialize
     ## get information about error correction
     necwords, nb1, nc1, nb2, nc2 = getecinfo(v, eclevel)
     ## initialize blocks
-    expand(x) = (8 * x - 7):8 * x
-    segments = vcat([Vector{Int}(undef, 8 * nc1) for _ in 1:nb1],
-                    [Vector{Int}(undef, 8 * nc2) for _ in 1:nb2])
-    ecsegments = [Vector{Int}(undef, 8 * necwords) for _ in 1:nb1 + nb2]
+    segments = vcat([Vector{Vector{CartesianIndex{2}}}(undef, nc1) for _ in 1:nb1],
+                    [Vector{Vector{CartesianIndex{2}}}(undef, nc2) for _ in 1:nb2])
+    ecsegments = [Vector{Vector{CartesianIndex{2}}}(undef, necwords) for _ in 1:nb1 + nb2]
     # get segments from the QR code
     ## indexes of message bits
     inds = getindexes(v)
@@ -77,16 +78,16 @@ function getsegments(v::Int, eclevel::ErrCorrLevel)
     ind = length(inds) >> 3 # number of bytes
     ### error correction bytes
     @inbounds for i in necwords:-1:1, j in (nb1 + nb2):-1:1
-        ecsegments[j][expand(i)] = @view(inds[expand(ind)])
+        ecsegments[j][i] = @view(inds[ind * 8 - 7:ind * 8])
         ind -= 1
     end
     ### message bytes
     @inbounds for i in nc2:-1:(1 + nc1), j in (nb1 + nb2):-1:(nb1 + 1)
-        segments[j][expand(i)] = @view(inds[expand(ind)])
+        segments[j][i] = @view(inds[ind * 8 - 7:ind * 8])
         ind -= 1
     end
     @inbounds for i in nc1:-1:1, j in (nb1 + nb2):-1:1
-        segments[j][expand(i)] = @view(inds[expand(ind)])
+        segments[j][i] = @view(inds[ind * 8 - 7:ind * 8])
         ind -= 1
     end
     ind != 0 && throw(ArgumentError("getsegments: not all data is recorded"))

--- a/src/styles/plotimage.jl
+++ b/src/styles/plotimage.jl
@@ -1,8 +1,4 @@
-#= Plot image inside QR code
-Set value of mask from 0 to 7.
-
-
-=#
+# Plot image inside QR code
 
 """
     imageinqrcode( code::QRCode
@@ -23,55 +19,58 @@ function imageinqrcode!( code::QRCode
                        ; rate::Real=1
                        , singlemask::Bool=false)
     # ---- preprocess ---- #
-        ## 1.1 check input
-        border, code.border = code.border, 0 # set border to 0
-        (imgx, imgy), qrlen = size(img), qrwidth(code)
-        qrlen ≥ max(imgx, imgy) || throw(ArgumentError("The image is too large."))
-        rate ≥ 0 || throw(ArgumentError("The rate should be positive."))
-        rate > 1 && @warn(ArgumentError(
-            " It could risk to destroy the message if rate is bigger that 1."))
-        
-        ## 1.2 number of modified bytes for each block
-        version, eclevel, mask = code.version, code.eclevel, code.mask
-        necwords, nb1, nc1, _, nc2 = getecinfo(version, eclevel)
-        modify = floor(Int, necwords * rate / 2)
+    ## 1.1 check input
+    border, code.border = code.border, 0 # set border to 0
+    (imgx, imgy), qrlen = size(img), qrwidth(code)
+    qrlen ≥ max(imgx, imgy) || throw(ArgumentError("The image is too large."))
+    rate ≥ 0 || throw(ArgumentError("The rate should be positive."))
+    rate > 1 && @warn(ArgumentError(
+        " It could risk to destroy the message if rate is bigger that 1."))
+    
+    ## 1.2 number of modified bytes for each block
+    version, eclevel, mask = code.version, code.eclevel, code.mask
+    necwords, nb1, nc1, _, nc2 = getecinfo(version, eclevel)
+    modify = floor(Int, necwords * rate / 2)
 
-        ## 1.3 plot image in canvas
-        canvas = rand(Bool, qrlen, qrlen) # canvas = similar(stdmat)
-        x1, y1 = 1 + (qrlen - imgx) >> 1, 1 + (qrlen - imgy) >> 1
-        x2, y2 = x1 + imgx - 1, y1 + imgy - 1
-        imgI = CartesianIndices((x1:x2, y1:y2))
-        canvas[imgI] = img
+    ## 1.3 plot image in canvas
+    canvas = rand(Bool, qrlen, qrlen) # canvas = similar(stdmat)
+    x1, y1 = 1 + (qrlen - imgx) >> 1, 1 + (qrlen - imgy) >> 1
+    x2, y2 = x1 + imgx - 1, y1 + imgy - 1
+    imgI = CartesianIndices((x1:x2, y1:y2))
+    canvas[imgI] = img
 
-        ## 1.4 get indexes of block bytes
-        bytemsginds, byteecinds = getsegments(code)
-        byteblockinds = [vcat(inds1, inds2) for (inds1, inds2) in zip(bytemsginds, byteecinds)]
-        bitblockinds = [vcat(inds...) for inds in byteblockinds]
+    ## 1.4 get indexes of block bytes
+    bytemsginds, byteecinds = getsegments(code)
+    msglens = length.(bytemsginds)
+    byteblockinds = [vcat(inds1, inds2) for (inds1, inds2) in zip(bytemsginds, byteecinds)]
+    bitblockinds = [vcat(inds...) for inds in byteblockinds]
 
-        ## 1.5 information of free blocks
-        npureblock, nfreeblock, nfreebyte = getfreeinfo(code)
-        npurebyte = (npureblock > nb1 ? nc2 : nc1) - nfreebyte # number of message bytes in the partial free block
-        bytefreeblockinds = @view(byteblockinds[npureblock + 2:end])
-        bitfreeblockinds = @view(bitblockinds[npureblock + 2:end])
+    ## 1.5 information of free blocks
+    npureblock, nfreeblock, nfreebyte = getfreeinfo(code)
+    ### one can set `nfreebyte=0` to skip modification of the partial-block
+    npurebyte = (npureblock ≥ nb1 ? nc2 : nc1) - nfreebyte # number of message bytes in the partial free block
+    bytefreeblockinds = @view(byteblockinds[npureblock + 2:end])
+    bitfreeblockinds = @view(bitblockinds[npureblock + 2:end])
+    freemsglens = @view(msglens[npureblock + 2:end])
 
-        ## 1.6 allocations
-        ### current bit block vals and free bit block vals
-        bitblockvals = [Vector{Bool}(undef, length(inds)) for inds in bitblockinds]
-        bitfreeblockvals = @view(bitblockvals[npureblock + 2:end])
+    ## 1.6 allocations
+    ### current bit block vals and free bit block vals
+    bitblockvals = [Vector{Bool}(undef, length(inds)) for inds in bitblockinds]
+    bitfreeblockvals = @view(bitblockvals[npureblock + 2:end])
 
-        ## 1.7 common data for different mask
-        ### sort bytes by the intersection area with the image
-        #### free blocks
-        sortfreebytes = [sortperm(count.(∈(imgI), bytefreeblockinds[i]), rev=true) for i in 1:nfreeblock]
-        #### partial free block
-        scores = @views count.(∈(imgI), bytefreeblockinds[npureblock + 1][npurebyte+1:end])
-        sortparinds = vcat(1:npurebyte, # the first `npurebyte`
-            npurebyte .+ sortperm(scores, rev=true))
+    ## 1.7 common data for different mask
+    ### sort bytes by the intersection area with the image
+    #### free blocks
+    sortfreebytes = [sortindsample(count.(∈(imgI), bytefreeblockinds[i]), freemsglens[i]) for i in 1:nfreeblock]
+    #### partial free block
+    scores = @views count.(∈(imgI), byteblockinds[npureblock + 1][npurebyte+1:end])
+    sortparinds = vcat(1:npurebyte, # the first `npurebyte`
+        npurebyte .+ sortindsample(scores, msglens[npureblock + 1] - npurebyte)) # the rest
 
     # ----- find best values of the bit blocks ----- #
     masks = singlemask ? [mask] : [0:7;]
     bestmat, bestpenalty = nothing, Inf
-    penalty(mat) = @views sum(mat[imgI] == img)
+    distance(mat) = @views sum(mat[imgI] == img)
     for mask in masks
         code.mask = mask
         stdmat = qrcode(code) # standard QR code
@@ -84,55 +83,48 @@ function imageinqrcode!( code::QRCode
             bitblockvals[i] = @view(stdmat[bitblockinds[i]])
         end
 
-        ## 2.3 free blocks -- error correction        
+        ## 2.3 free blocks -- fill blank       
         for i in 1:nfreeblock
-            bitvals = bitfreeblockvals[i] # **our target**
+            # initialize
             bitinds, byteinds = bitfreeblockinds[i], bytefreeblockinds[i]
-            sortinds = sortfreebytes[i]
-            reclen = length(byteinds) # length of the received message
-            msglen = reclen - necwords
-            validinds = @views sortinds[1:msglen]
-            # initialize byte values
-            bytevals = Vector{UInt8}(undef, reclen)
+            validinds = sortfreebytes[i]
+            # compute byte values
+            bytevals = Vector{UInt8}(undef, length(byteinds))
             for j in validinds # read from canvas
                 bytevals[j] = @views bitarray2int(canvas[byteinds[j]])
             end
             # fill the rest of bytes
             bytevals = fillblank(bytevals, validinds, necwords)
             # convert to bit values
-            for (i, byte) in enumerate(bytevals)
-                bitvals[i * 8 - 7:i * 8] = int2bitarray(byte)
+            for (j, byte) in enumerate(bytevals)
+                bitfreeblockvals[i][j * 8 - 7:j * 8] = int2bitarray(byte)
             end
             # apply mask
-            bitvals .⊻= @view(maskmat[bitinds])
+            bitfreeblockvals[i] .⊻= @view(maskmat[bitinds])
         end
         
         ## 2.4 partial free block -- read from standard QR matrix + error correction
         ### 2.4.1 our target: `bitvals`
-        bitvals = bitblockvals[npureblock + 1]
         bitinds, byteinds = bitblockinds[npureblock + 1], byteblockinds[npureblock + 1]        
         ### 2.4.2 error correction
-        reclen = length(byteinds) # length of the received message
-        msglen = reclen - necwords
-        validinds = @views sortparinds[1:msglen]
         #### initialize byte values
-        bytevals = Vector{UInt8}(undef, reclen)
+        bytevals = Vector{UInt8}(undef, length(byteinds))
         for i in 1:npurebyte # read from standard QR matrix
             # remove mask
             bits = @views stdmat[byteinds[i]] .⊻ maskmat[byteinds[i]]
             bytevals[i] = bitarray2int(bits)
         end
-        for i in @views sortparinds[npurebyte+1:msglen] # read from canvas
+        for i in @views sortparinds[npurebyte+1:end] # read from canvas
             bytevals[i] = @views bitarray2int(canvas[byteinds[i]])
         end
         #### fill the rest of bytes
-        bytevals = fillblank(bytevals, validinds, necwords)
+        bytevals = fillblank(bytevals, sortparinds, necwords)
         #### convert to bit values
         for (i, byte) in enumerate(bytevals)
-            bitvals[i * 8 - 7:i * 8] = int2bitarray(byte)
+            bitblockvals[npureblock + 1][i * 8 - 7:i * 8] = int2bitarray(byte)
         end
         #### apply mask
-        bitvals .⊻= @view(maskmat[bitinds])
+        bitblockvals[npureblock + 1] .⊻= @view(maskmat[bitinds])
 
         ## 2.5 fill in the QR matrix
         for (inds, vals) in zip(bitblockinds, bitblockvals)
@@ -145,15 +137,15 @@ function imageinqrcode!( code::QRCode
         for block in byteblockinds
             modify == 0 && break # no need to modify
             scores = bytecost.(block)
-            sortinds = sortperm(scores, rev=true)
-            errind = @views findfirst(iszero, scores[sortinds])
-            sortinds = @views sortinds[1:min(errind-1, modify)]
-            for byte in @views block[sortinds]
+            sortinds = sortindsample(scores, modify)
+            errind = @views findlast(!iszero, scores[sortinds])
+            isnothing(errind) && continue
+            for byte in @views block[sortinds[1:errind]]
                 stdmat[byte] = @view(canvas[byte])
             end
         end
-        ## 2.7 calculate penalty
-        penaltyval = penalty(stdmat)
+        ## 2.7 calculate distance
+        penaltyval = distance(stdmat)
         if penaltyval < bestpenalty
             bestmat, bestpenalty = stdmat, penaltyval
         end
@@ -205,7 +197,7 @@ function getfreeinfo( msg::AbstractString
     end
     # length of required bits
     requiredlen = 8 * (nb1 * nc1 + nb2 * nc2)
-    nonpadbits ≥ requiredlen && return 0, 0 # no free/partial-free block
+    nonpadbits ≥ requiredlen && return nb1 + nb2 - 1, 0, 0 # no free/partial-free block
 
     # number of bytes of *real* message bits
     msgbyte = nonpadbits >> 3
@@ -220,6 +212,7 @@ function getfreeinfo( msg::AbstractString
         nmsgblock = ceil(Int, msgbyte / nc2)
         nfreeblock = nb2 - nmsgblock
         nfreebyte = nc2 * nmsgblock - msgbyte
+        nmsgblock += nb1
     end
     npureblock = nmsgblock - 1
     return npureblock, nfreeblock, nfreebyte
@@ -239,4 +232,22 @@ function getimagescore(mat::AbstractMatrix{Bool}, img::AbstractMatrix{<:Bool})
     x1, y1 = 1 + (qrlen - imgx) >> 1, 1 + (qrlen - imgy) >> 1
     x2, y2 = x1 + imgx - 1, y1 + imgy - 1
     sum(mat[x1:x2, y1:y2] .!= img)
+end
+
+"""
+    sortindsample(scores::AbstractVector, msglen::Int)
+
+Return the indices of the sorted scores.
+
+We pick random indexes when there are too many scores that
+equals `8`. This can help decentralized the corrections.
+"""
+function sortindsample(scores::AbstractVector, msglen::Int)
+    inds = sortperm(scores, rev=true)
+    ind8 = findlast(==(8), scores[inds])
+    if !isnothing(ind8) && ind8 > msglen 
+        @views sample(inds[1:ind8], msglen; replace=false)
+    else
+        @view(inds[1:msglen])
+    end
 end

--- a/src/styles/plotimage.jl
+++ b/src/styles/plotimage.jl
@@ -1,152 +1,199 @@
-# 3. Plot image inside QR code
-## 3.1 use error correction
+#= Plot image inside QR code
+Set value of mask from 0 to 7.
+
+
+=#
 
 """
-    pickindexes(errinds::AbstractVector{<:Integer}, blockinds{<:Integer}, modify::Int)
+    imageinqrcode(code::QRCode, img::AbstractMatrix, rate::Real=1)
 
-Pick indexes from `blockinds` by `errinds`. The number of codewords that will be 
-modified is `modify`. Here 1 codeword = 8 bits.
+Plot image inside QR code.
 """
-function pickcodewords( errinds::AbstractVector{<:Integer}
-                      , validbytes::AbstractVector{<:AbstractVector}
-                      , modify::Int)
-    ## locate codewords
-    blocklen = length(validbytes)
-    modify ≥ blocklen && return validbytes
-    errinds = Set(errinds) # for fast searching
-    damages = [count(in(errinds), bytes) for bytes in validbytes]
-    ## sort by damage cost
-    inds = @views sort(1:blocklen, by=i->damages[i], rev=true)[1:modify]
-    # inds = @views inds[1:count(!iszero, damages)] # discard the correct bits
-    @views validbytes[inds]
-end
-
-function pack2bytes(inds::AbstractVector{<:Integer})
-    n = length(inds)
-    return [inds[i:i+7] for i in 1:8:n & 7 ⊻ n] # discard remainder bits
-end
-
-"""
-    imagebyerrcor(code::QRCode, targetmat::AbstractMatrix, rate::Real=2/3)
-
-Plot the image `targetmat` inside the QR code using error correction.
-
-In order to get the best simulation, the error correction level
-is recommended to be `High()`.
-
-The parameter `rate` is the rate of the error correction codewords
-that will be modified. The default value is `2/3`, which means that
-`1/2 * 2/3 = 1/3` of the error correction codewords will be modified.
-"""
-imagebyerrcor(code::QRCode, targtemat::AbstractMatrix; rate::Real=2/3) = imagebyerrcor!(copy(code), targtemat; rate=rate)
-
-function imagebyerrcor!( code::QRCode
-                       , targetmat::AbstractMatrix
-                       ; rate::Real=2/3)
-    ## check parameters
-    rate ≥ 0 || throw(ArgumentError("rate should be non-negative."))
-    rate ≤ 1 || @warn(ArgumentError("Invalid rate $rate." *
+function imageinqrcode( code::QRCode
+                      , img::AbstractMatrix
+                      ; rate::Real=1
+                      , singlemask=true)
+    # ---- preprocess ---- #
+        ## 1.1 check input
+        code.border == 0 || throw(ArgumentError("Border of the QR code should be 0"))
+        (imgx, imgy), qrlen = size(img), qrwidth(code)
+        qrlen ≥ max(imgx, imgy) || throw(ArgumentError("The image is too large."))
+        rate ≥ 0 || throw(ArgumentError("The rate should be positive."))
+        rate > 1 && @warn(ArgumentError(
             " It could risk to destroy the message if rate is bigger that 1."))
-    border, code.border = code.border, 0 # reset border -- compat to indexes rule
-    (imgx, imgy), qrlen = size(targetmat), qrwidth(code)
-    qrlen ≥ max(imgx, imgy) || throw(ArgumentError("The image is too large."))
-    
-    ## image position
-    x1, y1 = (qrlen - imgx + 1) >> 1, (qrlen - imgy + 1) >> 1
-    x2, y2 = x1 + imgx - 1, y1 + imgy - 1
-    function isvalid(p::Int)
-        x, y = p % qrlen, p ÷ qrlen
-        x1 ≤ x ≤ x2 && y1 ≤ y ≤ y2
-    end  
+        
+        ## 1.2 number of modified bytes for each block
+        version, eclevel, mask = code.version, code.eclevel, code.mask
+        necwords, nb1, nc1, _, nc2 = getecinfo(version, eclevel)
+        modify = floor(Int, necwords * rate / 2)
 
-    ## locations of message bits
-    version, eclevel = code.version, code.eclevel
-    msginds, ecinds = getsegments(version, eclevel)
-    # number of error correction codewords
-    necwords = length(first(ecinds)) >> 3
-    modify = floor(Int, necwords * rate / 2)
+        ## 1.3 standard QR matrix and masked matrix
+        stdmat = qrcode(code) # standard QR code
+        maskmat = makemask(emptymatrix(version), mask)
+        canvas = rand(Bool, qrlen, qrlen) # canvas = similar(stdmat)
 
-    # valid indexes
-    validmsgecinds = [vcat(inds1, inds2) for (inds1, inds2) in zip(msginds, ecinds)]
-    validbytes = [filter!.(isvalid, pack2bytes(inds)) for inds in validmsgecinds]
-    filter!.(isvalid, validmsgecinds) # filter out invalid indexes
-    validinds = vcat(validmsgecinds...)
-    # indexes inside the image
-    targetval(ind::Int) = targetmat[ind % qrlen - x1 + 1, ind ÷ qrlen - y1 + 1]
-      
-    ## cost function
-    penalty(newmat) = sum(newmat[validinds] .== targetval.(validinds))
-    ## enumerate over masks
-    bestmat, bestpenalty = nothing, Inf
-    for mask in 0:7
-        code.mask = mask
-        newmat = qrcode(code)
-        for (vinds, vbytes) in zip(validmsgecinds, validbytes) # enumerate over each blcok
-            errinds = filter(x -> newmat[x] != targetval(x), vinds)
-            bytes = pickcodewords(errinds, vbytes, modify)
-            @inbounds for inds in bytes
-                newmat[inds] = targetval.(inds)
+        ## 1.4 plot image in canvas
+        x1, y1 = (qrlen - imgx + 1) >> 1, (qrlen - imgy + 1) >> 1
+        x2, y2 = x1 + imgx - 1, y1 + imgy - 1
+        imgI = CartesianIndices((x1:x2, y1:y2))
+        canvas[imgI] = img
+        canvas .⊻= maskmat
+
+        ## 1.5 get indexes of block bytes
+        bytemsginds, byteecinds = getsegments(code)
+        byteblockinds = [vcat(inds1, inds2) for (inds1, inds2) in zip(bytemsginds, byteecinds)]
+        bitblockinds = [vcat(inds...) for inds in byteblockinds]
+
+        ## 1.6 information of free blocks
+        npureblock, nfreeblock, nfreebyte = getfreeinfo(code)
+        npurebyte = (npureblock > nb1 ? nc2 : nc1) - nfreebyte # number of message bytes in the partial free block
+        bytefreeblockinds = @view(byteblockinds[npureblock + 2:end])
+        bitfreeblockinds = @view(bitblockinds[npureblock + 2:end])
+
+    # ----- compute values of the bit blocks ----- #
+        ## 2.1 allocations
+        bitblockvals = [Vector{Bool}(undef, length(inds)) for inds in bitblockinds]
+        bitfreeblockvals = @view(bitblockvals[npureblock + 2:end])
+
+        ## 2.2 pure message block -- read from standard QR matrix
+        for i in 1:npureblock
+            bitblockvals[i] = @view(stdmat[bitblockinds[i]])
+        end
+
+        ## 2.3 free blocks -- error correction
+        ### sort bytes by the intersection area with the image
+        sortbytes = [sortperm(count.(∈(imgI), bytefreeblockinds[i]), rev=true) for i in 1:nfreeblock]
+        ### error correction
+        for i in 1:nfreeblock
+            bitvals = bitfreeblockvals[i] # **our target**
+            bitinds, byteinds = bitfreeblockinds[i], bytefreeblockinds[i]
+            sortinds = sortbytes[i]
+            reclen = length(byteinds) # length of the received message
+            msglen = reclen - necwords
+            validinds = @views sortinds[1:msglen]
+            # initialize byte values
+            bytevals = Vector{UInt8}(undef, reclen)
+            for j in validinds # read from canvas
+                bytevals[j] = @views bitarray2int(canvas[byteinds[j]])
             end
+            # fill the rest of bytes
+            bytevals = fillblank(bytevals, validinds, necwords)
+            # convert to bit values
+            for (i, byte) in enumerate(bytevals)
+                bitvals[i * 8 - 7:i * 8] = int2bitarray(byte)
+            end
+            # apply mask
+            bitvals .⊻= @view(maskmat[bitinds])
         end
-        newpenalty = penalty(newmat)
-        if newpenalty < bestpenalty
-            bestmat, bestpenalty = newmat, newpenalty
+        
+        ## 2.4 partial free block -- read from standard QR matrix + error correction
+        ### our target: `bitvals`
+        bitvals = bitblockvals[npureblock + 1]
+        bitinds, byteinds = bitblockinds[npureblock + 1], byteblockinds[npureblock + 1]
+        ### sort bytes by the intersection area with the image
+        scores = @views count.(∈(imgI), byteinds[npurebyte+1:end])
+        sortinds = vcat(1:npurebyte, # the first `npurebyte`
+            npurebyte .+ sortperm(scores, rev=true))
+        ### error correction
+        reclen = length(byteinds) # length of the received message
+        msglen = reclen - necwords
+        validinds = @views sortinds[1:msglen]
+        #### initialize byte values
+        bytevals = Vector{UInt8}(undef, reclen)
+        for i in 1:npurebyte # read from standard QR matrix
+            # remove mask
+            bits = @views stdmat[byteinds[i]] .⊻ maskmat[byteinds[i]]
+            bytevals[i] = bitarray2int(bits)
         end
-    end
-    # add white border
-    return addborder(bestmat, border)
-end
-
-"""
-    imagebyerrcor( message::AbstractString
-                , targetmat::AbstractMatrix
-                ; version::Int=16
-                , mode::Mode=Numeric()
-                , eclevel::ErrCorrLevel=High()
-                , width::Int=2
-                , rate::Real=2/3)
-
-Plot the image inside the QR code of `message` using error correction.
-"""
-function imagebyerrcor( message::AbstractString
-                      , targetmat::AbstractMatrix
-                      ; version::Int=16
-                      , mode::Mode=Numeric()
-                      , eclevel::ErrCorrLevel=High()
-                      , width::Int=0
-                      , rate::Real=2/3)
-    code = QRCode(message, version=version, eclevel=eclevel, mode=mode, width=width)
-    return imagebyerrcor!(code, targetmat, rate=rate)
-end
-
-"""
-    animatebyerrcor( codes::AbstractVector{QRCode}
-                   , targetmats::AbstractVector{<:AbstractMatrix}
-                   ; rate::Real=2/3
-                   , pixels::Int=160
-                   , fps::Int=10
-                   , filename::AbstractString="animate.gif")
-
-Plot the image inside the QR code of `message` using error correction,
-and save the animation to `filename`.
-"""
-function animatebyerrcor( codes::AbstractVector{QRCode}
-                        , targetmats::Vector{<:AbstractArray}
-                        , filename::AbstractString="animate.gif"
-                        ; rate::Real=2/3
-                        , pixels::Int=160
-                        , fps::Int=5)
-    width = qrwidth(first(codes))
-    all(==(width), qrwidth.(codes)) || throw(ArgumentError(
-        "All QR codes should have the same version."))
-    length(codes) == length(targetmats) || throw(ArgumentError(
-        "The number of QR codes should be equal to the number of target images."))
+        for i in @views sortinds[npurebyte+1:msglen] # read from canvas
+            bytevals[i] = @views bitarray2int(canvas[byteinds[i]])
+        end
+        #### fill the rest of bytes
+        bytevals = fillblank(bytevals, validinds, necwords)
+        #### convert to bit values
+        for (i, byte) in enumerate(bytevals)
+            bitvals[i * 8 - 7:i * 8] = int2bitarray(byte)
+        end
+        #### apply mask
+        bitvals .⊻= @view(maskmat[bitinds])
     
-    pixels = ceil(Int, pixels / width) * width
-    animate = Array{Bool}(undef, pixels, pixels, length(codes))
-    @inbounds for (i, code) in enumerate(codes)
-        mat = imagebyerrcor(code, targetmats[i], rate=rate)
-        animate[:, :, i] = _resize(mat, pixels)
+    # ----- fill in by the modified bits ----- #
+    for (inds, vals) in zip(bitblockinds, bitblockvals)
+        stdmat[inds] = vals
     end
-    save(filename, .! animate, fps=fps)
+    # ----- return the modified QR code ----- #
+    canvas .⊻= maskmat # remove the mask
+    bytecost(byte) = count(ind->stdmat[ind] != canvas[ind], filter(∈(imgI), byte))
+    for block in byteblockinds
+        sortinds = sortperm(bytecost.(block), rev=true)
+        for byte in @views block[sortinds[1:modify]]
+            stdmat[byte] = @view(canvas[byte])
+        end
+    end
+    return stdmat
 end
+
+"""
+    getfreeinfo( msg::AbstractString
+               , mode::Mode
+               , eclevel::ErrCorrLevel
+               , version::Int)
+
+Return the number of free blocks and the number of bytes
+of the partial-free block.
+
+## Background
+1. required bits
+    requiredbits = mode indicator # 4 bits 
+                + ccindicator(mode, version)
+                + databits(msg, mode)
+                + padbits # free bits(* important)
+                = 8 * (nb1 * nc1 + nb2 * nc2)
+
+2. messge block and error correction block
+   - message blocks are splited from required bits
+   - each msgblock is associated with an ecblock
+
+3. message bits
+    messagebits = msgblocks + ecblocks + remainder bits
+"""
+function getfreeinfo( msg::AbstractString
+                    , mode::Mode
+                    , eclevel::ErrCorrLevel
+                    , version::Int)
+    # number of blocks
+    _, nb1, nc1, nb2, nc2 = getecinfo(version, eclevel)
+
+    # length of non-padbits
+    modelen = 4 # length of mode indicator
+    i = (version ≥ 1) + (version ≥ 10) + (version ≥ 27)
+    cclen = charactercountlength[mode][i] # length of character count bits
+    datalen = length(encodedata(msg, mode)) # length of data bits
+    nonpadbits = modelen + cclen + datalen
+    # pad 0 to make the length of bits a multiple of 8
+    mod8 = nonpadbits & 7
+    if mod8 != 0
+        nonpadbits += 8 - mod8
+    end
+    # length of required bits
+    requiredlen = 8 * (nb1 * nc1 + nb2 * nc2)
+    nonpadbits ≥ requiredlen && return 0, 0 # no free/partial-free block
+
+    # number of bytes of *real* message bits
+    msgbyte = nonpadbits >> 3
+    grp1 = nb1 * nc1 # number of bytes of group 1
+    if msgbyte ≤ grp1
+         # number of blocks of the message
+        nmsgblock = ceil(Int, msgbyte / nc1)
+        nfreeblock = nb2 + nb1 - nmsgblock
+        nfreebyte = nc1 * nmsgblock - msgbyte
+    else
+        msgbyte -= grp1
+        nmsgblock = ceil(Int, msgbyte / nc2)
+        nfreeblock = nb2 - nmsgblock
+        nfreebyte = nc2 * nmsgblock - msgbyte
+    end
+    npureblock = nmsgblock - 1
+    return npureblock, nfreeblock, nfreebyte
+end
+getfreeinfo(code::QRCode) = getfreeinfo(code.message, code.mode, code.eclevel, code.version)

--- a/src/styles/style.jl
+++ b/src/styles/style.jl
@@ -21,3 +21,6 @@ include("locate.jl")
 
 # Plot image inside QR code
 include("plotimage.jl")
+
+# solve equations
+include("equation.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,9 +24,9 @@ using QRCoders:
     # data convert
     bitarray2int, int2bitarray, bits2bytes,
     # style
-    unicodeplot, getindexes, getsegments,
-    imagebyerrcor, animatebyerrcor,
-    pickcodewords, getecinfo,
+    unicodeplot, getindexes, getsegments, getecinfo,
+    # imagebyerrcor, animatebyerrcor,
+    # pickcodewords,
     gauss_elimination, fillblank
                  
 using QRCoders.Polynomial:
@@ -63,11 +63,11 @@ include("tst_construct.jl")
 # original tests
 include("tst_overall.jl")
 
-# style
-include("tst_style.jl")
-
 # equations
 include("tst_equation.jl")
+
+# style
+include("tst_style.jl")
 
 # final message
 unicodeplotbychar("https://github.com/JuliaImages/QRCoders.jl") |> println

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using ImageTransformations
 using TestImages
 using StatsBase
 using QRDecoders.Syndrome: fillerasures!
+using QRDecoders: qrdecode
 
 using QRCoders:
     # build
@@ -25,7 +26,7 @@ using QRCoders:
     bitarray2int, int2bitarray, bits2bytes,
     # style
     unicodeplot, getindexes, getsegments, getecinfo,
-    gauss_elimination, fillblank
+    gauss_elimination, fillblank, getimagescore
                  
 using QRCoders.Polynomial:
     # operator for GF(256) integers

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,8 +25,6 @@ using QRCoders:
     bitarray2int, int2bitarray, bits2bytes,
     # style
     unicodeplot, getindexes, getsegments, getecinfo,
-    # imagebyerrcor, animatebyerrcor,
-    # pickcodewords,
     gauss_elimination, fillblank
                  
 using QRCoders.Polynomial:
@@ -68,6 +66,9 @@ include("tst_equation.jl")
 
 # style
 include("tst_style.jl")
+
+# qrimage
+include("tst_qrimage.jl")
 
 # final message
 unicodeplotbychar("https://github.com/JuliaImages/QRCoders.jl") |> println

--- a/test/tst_construct.jl
+++ b/test/tst_construct.jl
@@ -47,6 +47,10 @@
         code = QRCode(msg; eclevel=eclevel, mode=mode, version=version, width=0)
         @test mat == qrcode(code)
     end
+
+    # curry apply
+    code = QRCode("Hello world!", width=0)
+    code |> qrcode |> addborder(2) |> exportbitmat(imgpath * "qrcode-curry")
 end
 
 @testset "Generate QRCode -- small cases" begin

--- a/test/tst_equation.jl
+++ b/test/tst_equation.jl
@@ -1,4 +1,5 @@
 # Test for Gauss elimination
+"""fill blank using Forney algorithm"""
 function fillblankbyFA( block::AbstractVector{<:Integer}
                       , misinds::AbstractVector{<:Integer}
                       , necwords::Int)

--- a/test/tst_qrimage.jl
+++ b/test/tst_qrimage.jl
@@ -1,0 +1,25 @@
+# plot image in qrcode
+"""
+    recommendshape(code::QRCode, img::AbstractMatrix)
+"""
+function recommentshape(code::QRCode, img::AbstractMatrix)
+    qrlen = qrwidth(code) - 2 * code.border
+    imgx, imgy = size(img)
+    recx = qrlen - 2 * 9 # skip the finder patterns and format information
+    recy = qrlen
+    rate = min(recx / imgx, recy / imgy)
+    imgx, imgy = floor(Int, imgx * rate), floor(Int, imgy * rate)
+    imresize(img, (imgx, imgy))
+end
+
+
+@testset "simulate image" begin
+    # image in qrcode
+    code = QRCode("HELLO WORLD", eclevel=High(), version=10, width=4)
+    img = testimage("cam")
+    img = .!(Bool.(round.(recommentshape(code, img))))
+    mat = imageinqrcode(code, img, rate=1, singlemask=false)
+    mat |> unicodeplotbychar |> println
+    exportbitmat(mat, "testimages/cam.png")
+    @test true
+end

--- a/test/tst_qrimage.jl
+++ b/test/tst_qrimage.jl
@@ -1,25 +1,60 @@
 # plot image in qrcode
-"""
-    recommendshape(code::QRCode, img::AbstractMatrix)
-"""
-function recommentshape(code::QRCode, img::AbstractMatrix)
-    qrlen = qrwidth(code) - 2 * code.border
+
+function reshapewidth(img::AbstractMatrix, width::Int)
     imgx, imgy = size(img)
-    recx = qrlen - 2 * 9 # skip the finder patterns and format information
-    recy = qrlen
-    rate = min(recx / imgx, recy / imgy)
+    rate = width / max(imgx, imgy)
     imgx, imgy = floor(Int, imgx * rate), floor(Int, imgy * rate)
     imresize(img, (imgx, imgy))
 end
 
-
 @testset "simulate image" begin
     # image in qrcode
-    code = QRCode("HELLO WORLD", eclevel=High(), version=10, width=4)
-    img = testimage("cam")
-    img = .!(Bool.(round.(recommentshape(code, img))))
+    code = QRCode("HELLO WORLD", eclevel=Low(), version=20, width=4)
+    oriimg = testimage("cam")
+    qrlen = qrwidth(code) - 2 * code.border # length of QR matrix
+    insidelen = qrlen - 16 # skip finder patterns
+    # full inside
+    img = .!(Bool.(round.(reshapewidth(oriimg, insidelen))))
     mat = imageinqrcode(code, img, rate=1, singlemask=false)
-    mat |> unicodeplotbychar |> println
-    exportbitmat(mat, "testimages/cam.png")
+    @test getimagescore(mat, img) ≤ 100
+    exportbitmat(mat, "testimages/cam_fullinside.png")
     @test true
+    # full screen
+    img = .!(Bool.(round.(reshapewidth(oriimg, qrlen))))
+    mat = imageinqrcode(code, img, rate=1, singlemask=false)
+    exportbitmat(mat, "testimages/cam_fullscreen.png")
+    @test true
+
+    # QR code with too much information
+    code = QRCode("hello world!"^55, width=4)
+    oriimg = testimage("cam")
+    qrlen = qrwidth(code) - 2 * code.border # length of QR matrix
+    insidelen = qrlen - 16 # skip finder patterns
+    # full inside
+    img = .!(Bool.(round.(reshapewidth(oriimg, insidelen))))
+    mat = imageinqrcode(code, img, rate=1, singlemask=false)
+    exportbitmat(mat, "testimages/cam_fullinside2.png")
+    @test true
+    # full screen
+    img = .!(Bool.(round.(reshapewidth(oriimg, qrlen))))
+    mat = imageinqrcode(code, img, rate=1, singlemask=false)
+    exportbitmat(mat, "testimages/cam_fullscreen2.png")
+    @test true
+
+    # test getecinfo
+    _, nb1, _, nb2 = getecinfo(code)
+    npureblock, nfreeblock, nfreebyte = getfreeinfo(code)
+    @test nb1 + nb2 == npureblock + nfreeblock + 1
+
+    # badapple
+    # oriimg = load("testimages/badapple.png")
+    # code = QRCode("HELLO WORLD", eclevel=High(), version=13, width=4)
+    # qrlen = qrwidth(code) - 2 * code.border # length of QR matrix
+    # insidelen = qrlen - 16 # skip finder patterns
+    # img = .!(Bool.(round.(Gray.(reshapewidth(oriimg, insidelen)))))
+    # mat = imageinqrcode(code, img, rate=1, singlemask=true)
+    # mat |> exportbitmat("testimages/badapple_fullinside")
+    # img = .!(Bool.(round.(Gray.(reshapewidth(oriimg, qrlen)))))
+    # mat = imageinqrcode(code, img, rate=.9, singlemask=true)
+    # mat |> exportbitmat("testimages/badapple_fullscreen")
 end

--- a/test/tst_style.jl
+++ b/test/tst_style.jl
@@ -43,8 +43,8 @@ end
         necwords, nb1, nc1, nb2, nc2 = ecblockinfo[eclevel][v, :]
         requiredbits = 8 * (nb1 * nc1 + nb2 * nc2)
         segments, ecsegments = getsegments(v, eclevel)
-        msginds = vcat(segments...)
-        ecinds = vcat(ecsegments...)
+        msginds = vcat(vcat(segments...)...)
+        ecinds = vcat(vcat(ecsegments...)...)
         ## check the length of message segments
         @test length(msginds) == requiredbits
         
@@ -69,8 +69,8 @@ end
     msg = "HELLO WORLD"
     mat = qrcode(msg, mode=mode, eclevel=eclevel, version=7, mask=0, width=0)
     segments, ecsegments = getsegments(7, eclevel)
-    msginds = vcat(segments...)
-    ecinds = vcat(ecsegments...)
+    msginds = vcat(vcat(segments...)...)
+    ecinds = vcat(vcat(ecsegments...)...)
     mat[msginds] .= 1
     mat[ecinds] .= 1
     unicodeplotbychar(mat) |> println
@@ -82,7 +82,7 @@ end
     img = testimage("cam")
     img = .!(Bool.(round.(imresize(img, 37, 37))))
     code = QRCode("HELLO WORLD", eclevel=High(), version=16, width=4)
-    mat = imagebyerrcor(code, img, rate=2/3)
+    mat = imageinqrcode(code, img, rate=2/3)
     exportbitmat(mat, "testimages/cam.png")
     @test true
     mat = imagebyerrcor("hello world!", img, version=10, width=2, rate=1.1)

--- a/test/tst_style.jl
+++ b/test/tst_style.jl
@@ -76,23 +76,3 @@ end
     unicodeplotbychar(mat) |> println
     @test true
 end
-
-@testset "simulate image" begin
-    # image in qrcode
-    img = testimage("cam")
-    img = .!(Bool.(round.(imresize(img, 37, 37))))
-    code = QRCode("HELLO WORLD", eclevel=High(), version=16, width=4)
-    mat = imageinqrcode(code, img, rate=2/3)
-    exportbitmat(mat, "testimages/cam.png")
-    @test true
-    mat = imagebyerrcor("hello world!", img, version=10, width=2, rate=1.1)
-    mat |> unicodeplotbychar |> println
-    @test true
-
-    # test for animate
-    code = QRCode("HELLO WORLD", eclevel=High(), version=16, width=4)
-    code2 = QRCode("Hello julia!", eclevel=High(), version=16, width=4)
-    codes = [code, code2]
-    animatebyerrcor(codes, [img, img], "testimages/cam.gif", rate=2/3)
-    @test true
-end

--- a/test/tst_style.jl
+++ b/test/tst_style.jl
@@ -40,6 +40,7 @@ end
 
     # get segments of the QR code
     for v in 1:40
+        v = 1
         necwords, nb1, nc1, nb2, nc2 = ecblockinfo[eclevel][v, :]
         requiredbits = 8 * (nb1 * nc1 + nb2 * nc2)
         segments, ecsegments = getsegments(v, eclevel)
@@ -47,6 +48,9 @@ end
         ecinds = vcat(vcat(ecsegments...)...)
         ## check the length of message segments
         @test length(msginds) == requiredbits
+        inds = getindexes(v)
+        byteinds = vcat(msginds..., ecinds...)
+        @test inds[1:length(byteinds)] == byteinds
         
         # test for QR matrix
         ## read from encoding process
@@ -61,6 +65,9 @@ end
         msgbits = mat[msginds]
         @test encoded == msgbits
     end
+    # dispatch for QRCode
+    code = QRCode("hello world")
+    @test getindexes(code) == getindexes(code.version)
 end
 
 @testset "display -- use white modules in msgbits" begin


### PR DESCRIPTION
The best approximation in version `20` is like 
![qrcode](https://user-images.githubusercontent.com/62223937/202883284-04335310-34a7-4605-a50c-a74663237293.png)
The modify-rate is `0.013`(`95` pixels from an `83x83=6889` image).

Note: it might take a few seconds to scan, one can try the "scan from image" option or use the online [QR-code reader](https://www.onlinebarcodereader.com/) instead.
